### PR TITLE
[WIP] Copy edit suggestions and front end guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,10 @@
 # Engineering Playbook
 
-## Overview
+## Purpose
 
-The beginnings of an engineering playbook for Truss.
+Within Truss we have much experience of and opinions regarding engineering tools, processes, and practices. The problems and choices that we encounter in our day-to-day practice are rarely new. Having a straightforward way of applying the things we collectively know to the problems we face would be a source of great efficiency for us.
 
-### Purpose
-
-Within the company we have a bunch of experience of and opinions about engineering tools, processes and practices. The problems and choices that we encounter in our day-to-day practice are rarely completely new. Having a straightforward way of applying the things we collectively know to the problems we collectively face would be a source of great efficiency for us.
-
-This collection of documents is intended to be that way; simple, searchable documents with each one containing the essence of Truss opinions on a particular topic. Whilst any Trussel is, and should feel, free to edit these documents there is some expectation that these are curated/blessed by the broad engineering community at Truss. To that end, proposed changes should be submitted via a PR and we hope SMEs will be identified to act as curators for particular areas of knowledge.
-
-### "Why this format. Wouldn't a Wiki/Google Docs/Web Pages/... be better?"
-
-Storing the source of these documents as text/markdown lets us render it in other forms, e.g. Web Pages, easily enough.
-
-Having the text in source control aids the curation goal via the well established practise of PRs and associated reviews.
+This collection of documents is intended to be simple and searchable, each one containing the essence of Truss opinions on a particular topic. Whilst any Trussel is free to edit these documents, there is some expectation that these are to be curated by the broad engineering community at Truss. To that end, proposed changes should be submitted via a PR and  SMEs will be identified to act as curators for particular areas of knowledge.
 
 ### Public repo
 

--- a/developing/README.md
+++ b/developing/README.md
@@ -4,7 +4,7 @@
 
 This section addresses the tools and practices which are part of the everyday habits of being a Software Engineer at Truss.
 
-In this, as in all things, Truss aims to find a balance between giving people the autonomy and tools to make the best choices in whatever situation they find themselves and avoiding revisiting questions again and again. The latter is especially true where the question is not material or core to how we do business. In some cases, we have strong opinions about which questions are not valuable as a cause for debate, e.g. [Tabs vs Spaces](https://truss.works/blog/2017/11/3/tabs-vs-spaces-a-tale-of-asking-the-wrong-questions).
+Truss aims to find a balance between giving the autonomy and tools to make the best choices in any given situation, but to also avoid revisiting the same questions again and again. The latter is especially true when the question is not material or core to how we do business. In some cases, we have strong opinions about which questions are not valuable as a cause for debate, e.g. [Tabs vs Spaces](https://truss.works/blog/2017/11/3/tabs-vs-spaces-a-tale-of-asking-the-wrong-questions).
 
 Generally, our approach should be "if there is a suggestion or answer in these pages, follow it until you have a *compelling* reason not to". Once you have a compelling reason to change the practice document it by adding to or updating these pages.
 

--- a/developing/cycle/README.md
+++ b/developing/cycle/README.md
@@ -6,6 +6,7 @@ The kind of iterative development we do consists of a number of repeated cycles 
 
 TBD Talk about cycle length, priorities for cycle & tooling
 
+<!---
 ## Contents
 
 * [Sprint Planning](./planning.md)
@@ -13,3 +14,4 @@ TBD Talk about cycle length, priorities for cycle & tooling
 * [Demo](./demo.md)
 * [Retrospective](./retro.md)
 * [Tooling/Tracker](./tracker.md)
+--->

--- a/developing/eid/README.md
+++ b/developing/eid/README.md
@@ -2,12 +2,11 @@
 
 ## Overview
 
-We really don't care which editor/IDE/debugger that you use - its your workflow. That said, we do think there is enormous value to be had from a well configured working environment that leverages available tooling. For example, knowing how to use some form of debugger will significantly improve your productivity and reduce the daily frustrations of developing code.
+We don't care which editor/IDE/debugger that you use - it's your workflow. That said, we do think there is enormous value to be had from a well configured working environment that leverages available tooling. For example, knowing how to use some form of debugger will significantly improve your productivity and reduce the daily frustrations of developing code.
 
 In this section you will find overviews of the range of tools to use and suggestions on how best to configure each tool for the situations we most often use them.
 
-What you should not find is gratuitous shade being thrown about particular editors or debuggers. Hell, we even have the odd emacs user.
-
 ## Contents
 
-Add some stuff here
+List of editors that Truss engineers use:
+- TBA

--- a/developing/languages/README.md
+++ b/developing/languages/README.md
@@ -6,6 +6,13 @@ This section will contain our collective observations about the strengths and ch
 
 While Truss may have opinions on particular languages and strategic reasons for investing in some languages over others, we recognize that our clients will may make different choices for different reasons. As such, Trussels should aim to be proficient in more than one language and able to get by with several.
 
-## Contents
-
-Add some stuff here
+## Languages Trussels are proficient in:
+- Go
+- JavaScript (including TypeScript/FlowScript)
+- Swift
+- Rust
+- Kotlin
+- Ruby
+- Python
+- Java
+- C/C++

--- a/developing/vcs/README.md
+++ b/developing/vcs/README.md
@@ -4,7 +4,9 @@
 
 Source control has less to do with the vcs system you use and more to do with the stages code goes through on the journey from inside a developers head, tested and merged into the main line, deployed to production and thence in time to being identified as that accursed legacy system that is causing all the problems.
 
+<!---
 ## Contents
 
 * [Branch Management](./branches.md)
 * [Pull Requests and Code reviews](./prs.md)
+--->

--- a/infra/README.md
+++ b/infra/README.md
@@ -4,6 +4,14 @@
 
 Infrastructure/Deployment is rilly rilly important - much too important for humans to do. If at all possible - automate it
 
-## Contents
+## Immutable infrastructure techniques
+- Packer
+- Containers (Docker)
+- Functions as a Service (Lambda, etc)
+- Terraform
 
-Please add some content - its rilly rilly important
+## Infrastructure as code techniques
+- Terraform
+- CloudFormation
+- Concourse-CI
+- Circle-CI

--- a/web/README.md
+++ b/web/README.md
@@ -5,7 +5,4 @@
 This is a really broad area. Topics range from languages and high level frameworks (Django, RoR, Golang), though specific usage patterns e.g. how best to use Redux as a data store for Flux based single page Javascript apps and down to particulars like how to manage session state in an HTTP based application.
 
 ## Contents
-
-Need to think about a good top level ontology for such a broad topic
-
-* [Testing Frameworks](testing/)
+* [Front End Guide](frontend/)

--- a/web/frontend/README.md
+++ b/web/frontend/README.md
@@ -1,0 +1,17 @@
+# [Front End Guide](../README.md) / Web Development
+
+## Overview
+These are recommendations for front end development.
+
+### Frameworks
+We typically choose React as our front end framework of choice.
+
+### Testing
+- Jest
+- Enzyme
+
+### Style Guide
+We generally adhere to the [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript), unless they conflict with project specific Prettier or lint rules.
+
+### CSS
+Follow the BEM (Block, Element, Modifier) methodology. Also helpful to follow is the [U.S. Web Design System](https://designsystem.digital.gov/components/).


### PR DESCRIPTION
This is my first attempt of suggested updates to Engineering Playbook.
- Succinct copyedits to main README and subsequent sections.
- Add starter list of programming languages and infrastructure tools.
- Add front end guide.

This is a WIP to start discussion if this is a desired direction for the playbook to go in, and approved/agreed upon edits and sections can potentially be new PRs. 