### PR TITLE
Fixes suggested by @ntwyman

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -4,7 +4,7 @@
 
 Infrastructure/Deployment is rilly rilly important - much too important for humans to do. If at all possible - automate it.
 
-Click [here](./getting_started) to get started with AWS and Terraform.
+Click [here](./getting_started/README.md) to get started with AWS and Terraform.
 
 ## Immutable infrastructure techniques
 

--- a/infra/aws/naming.md
+++ b/infra/aws/naming.md
@@ -1,6 +1,6 @@
 # [aws](./README.md) / Naming
 
-*Naming* is one of the [hard problems in computing](https://martinfowler.com/bliki/TwoHardThings.html). This page contains patterns for naming things (resourcesw, roles, policies etc) in AWS.
+*Naming* is one of the [hard problems in computing](https://martinfowler.com/bliki/TwoHardThings.html). This page contains patterns for naming things (resources, roles, policies, etc.) in AWS.
 
 ## Context
 
@@ -17,7 +17,7 @@ As with all naming schemes (and other stylistic things such as casing and commen
 * *$account.alias* - is a prefix for the account, e.g. "truss", "client-name"
 * *$application-name* - is application for which the resource is created, e.g. "aws-logs", "webserver", "terraform-state"
 * *$environment* - can be used to distinguish different versions of the resource/app that occur during the development lifecycle, e.g. `dev`, `perf_test`, `staging` and `prod`uction
-* *$region* - when an app can or will be distributed across AWS regions with distinct ionstances in each region, this postfix distinguishes between them
+* *$region* - when an app can or will be distributed across AWS regions with distinct instances in each region, this postfix distinguishes between them
 
 e.g.
 
@@ -41,7 +41,7 @@ e.g.
 
 ### Policies
 
-Where the details of an IAM role are in an associated policy  (usually the case) they are named after the associated role, but with `-policy` appended, e.g.
+Where the details of an IAM role are in an associated policy (usually the case) they are named after the associated role, but with `-policy` appended, e.g.
 
 * lambda-rds-snapshot-cleaner-app-experimental-policy
 * ecs-task-role-app-client-tls-experimental-policy
@@ -53,7 +53,7 @@ Where the name is scoped by the resource type and the region, e.g. lambda functi
 *${purpose}[-${application}]-${environment}* - is the general form
 
 * *$purpose* - a simple name describing the role/purpose of the resource, e.g. "slack-pivotal-bot", "webserver", "rds-log-cleaner"
-* *$application* - if needed, disambiguates between a simillar purpose across applications, e.g. "webapp" vs "honeycomb"
+* *$application* - if needed, disambiguates between a similar purpose across applications, e.g. "webapp" vs "honeycomb"
 * *$environment* - can be used to distinguish different versions of the resource/app that occur during the development lifecycle, e.g. `dev`, `perf_test`, `staging` and `prod`uction
 
 e.g.

--- a/infra/getting_started/README.md
+++ b/infra/getting_started/README.md
@@ -1,3 +1,4 @@
 # [infra](../README.md) / Getting Started
+
 1. [AWS Setup](./aws_setup.md)
 2. [Your First Lambda Function](./your_first_lambda_function.md)

--- a/infra/getting_started/your_first_lambda_function.md
+++ b/infra/getting_started/your_first_lambda_function.md
@@ -22,14 +22,14 @@ This tutorial focuses on deploying a "Hello, World" Go program as a Lambda funct
 3. Set your current directory to `hello-lambda`.
 4. AWS has kindly provided a Go library to develop Lambda functions. Let's install it.
 
-    ```
+    ```shell
     go get github.com/aws/aws-lambda-go/lambda
     ```
 
 5. Create a new file called `main.go`. This will contain the code that runs in our Lambda function.
 6. Within `main.go`:
 
-    ```
+    ```go
     package main
 
     import (
@@ -48,16 +48,17 @@ This tutorial focuses on deploying a "Hello, World" Go program as a Lambda funct
 
     Let's dissect this program for a second.
 
-    As you can see, we imported the AWS library we installed. We then utilize it to call `lambda.Start()`. This takes a handler function that will be called when a request comes in. 
+    As you can see, we imported the AWS library we installed. We then utilize it to call `lambda.Start()`. This takes a handler function that will be called when a request comes in.
 
     The handler in this case is our function `hello`. This handler is relatively simple. It doesn't take any internal Lambda requests and just returns the classic "Hello, world!".
 
 7. All that's left is to transform our Go program into something Lambda can actually run. We can accomplish this by creating a binary and storing it in a `.zip` file.
 
-    ```
+    ```shell
     env GOOS=linux GOARCH=amd64 go build -o main main.go
     zip main.zip main
     ```
+
     You'll notice that we are setting some environment variables using `usr/bin/env` before calling `go build`. This is because when we normally run `go build`, Go assumes that an executable will be built for the architecture that the program what written on. In this case, we want it to run on Linux and an amd64 architecure, so we set the Go "OS" (GOOS) and the Go "Architecture" (GOARCH). Using the `-o` flag allows us to specify the name and location of the executable produced by `go build`.
 
 ## Deploying with Terraform
@@ -66,7 +67,7 @@ This tutorial focuses on deploying a "Hello, World" Go program as a Lambda funct
 2. Open that new file up in your favorite text editor or IDE.
 3. Before we create our Lambda function, we need to tell Terraform the basics such as that we'll be deploying to AWS and what region we'll be deploying this function to.
 
-    ```
+    ```terraform
     variable "aws_region" {
         default = "us-west-2"
     }
@@ -78,7 +79,7 @@ This tutorial focuses on deploying a "Hello, World" Go program as a Lambda funct
 
 4. Let's create that Lambda function. Add the following lines to the file. Click [here](../aws/naming.md) for more on how we name our AWS resources.
 
-    ```
+    ```terraform
     resource "aws_lambda_function" "hello_world_test" {
         filename = "main.zip"
         function_name = "hello-world-test"
@@ -102,7 +103,8 @@ This tutorial focuses on deploying a "Hello, World" Go program as a Lambda funct
     `source_code_hash` is used to trigger updates when your source code changes.
 
 5. What's left to do finish `main.tf` is creating that IAM role.
-    ```
+
+    ```terraform
     resource "aws_iam_role" "lambda_hello_world_test_policy" {
         name = "lambda-hello-world-test-policy"
 
@@ -128,26 +130,34 @@ This tutorial focuses on deploying a "Hello, World" Go program as a Lambda funct
 
 6. Save the file.
 7. Back on the command line, it's time to initialize the setup for your Terraform plan.
-   ```
+
+   ```shell
    terraform init
    ```
+
 8. If that's looking good, let's check out what our plan looks like.
-    ```
+
+    ```shell
     terraform plan
     ```
+
 9. Once you've read over the plan, it's time to deploy your function!
-    ```
+
+    ```shell
     terraform apply
     ```
 
 ## Invoking your Lambda function
 
 1. To first check if you deployed successfully, let's print out a list of the existing Lambda functions.
-    ```
+
+    ```shell
     aws lambda list-functions --region=us-west-2
     ```
+
 2. Once you confirm your function is within that list, invoke your function!
-   ```
+
+   ```shell
    aws lambda invoke --function-name=lambda-hello-world-test output.txt
    ```
 
@@ -158,23 +168,28 @@ This tutorial focuses on deploying a "Hello, World" Go program as a Lambda funct
 Let's say you want your shiny new Lambda function to run every day. Maybe every hour! To do this, you will need to use another AWS service called [CloudWatch](https://aws.amazon.com/cloudwatch/). Let's open our `main.tf` up again and add a few things:
 
 1. Add a CloudWatch rule that specifies how often the event will trigger. [This article](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html) has more info on how to use the `schedule_expression` value.
-    ```
+
+    ```terraform
     resource "aws_cloudwatch_event_rule" "run_hello_world_lambda_every_hour_test" {
       name = "run-hello-world-lambda-every-hour-test"
       description = "Fires the hello world lambda every hour"
       schedule_expression = "rate(1 hour)"
     }
     ```
+
 2. Specify a target, our Lambda function.
-    ```
+
+    ```terraform
     resource "aws_cloudwatch_event_target" "cloudwatch_event_target_hello_world_lambda_test" {
       rule = "${aws_cloudwatch_event_rule.every_hour.name}"
       target_id = "hello-world-test"
       arn = "${aws_lambda_function.hello_world_test.arn}"
     }
     ```
+
 3. Make sure CloudWatch has permission to invoke the Lambda function.
-    ```
+
+    ```shell
     resource "aws_lambda_permission" "permit_hello_world_lambda_execution_from_cloudwatch_test" {
       statement_id = "AllowExecutionFromCloudWatch"
       action = "lambda:InvokeFunction"
@@ -183,13 +198,14 @@ Let's say you want your shiny new Lambda function to run every day. Maybe every 
       source_arn = "${aws_cloudwatch_event_rule.every_hour.arn}"
     }
     ```
+
 4. Run our Terraform commands form the command line: `terraform plan` and `terraform apply`.
 
 5. Your function will now run every hour!
 
 ## Cleaning up
 
-We've been hard at work setting up our Lambda function, but let's face it &mdash; we probably won't be relying on it as part of our production infrastructure. This is a good opportunity to learn about taking down infrastructure with Terraform. __Make sure you are inside the correct directory when running the following commands!__ 
+We've been hard at work setting up our Lambda function, but let's face it &mdash; we probably won't be relying on it as part of our production infrastructure. This is a good opportunity to learn about taking down infrastructure with Terraform. __Make sure you are inside the correct directory when running the following commands!__
 
 1. Run `terraform plan -destroy`, to generate a plan for destroying the infrastructure you have created. You'll see a list of all the resources you created in your `main.tf` file.
 2. If everything in the list looks good, you can run `terraform apply`'s destructive counterpart, `terraform destroy`. It's like our Lambda function was never even there!

--- a/infra/getting_started/your_first_lambda_function.md
+++ b/infra/getting_started/your_first_lambda_function.md
@@ -83,7 +83,7 @@ This tutorial focuses on deploying a "Hello, World" Go program as a Lambda funct
     resource "aws_lambda_function" "hello_world_test" {
         filename = "main.zip"
         function_name = "hello-world-test"
-        role             = "${aws_iam_role.lambda-hello-world-test.arn}"
+        role             = "${aws_iam_role.lambda_hello_world_test_policy.arn}"
         handler          = "main"
         source_code_hash = "${base64sha256(file("main.zip"))}"
         runtime          = "go1.x"
@@ -109,20 +109,20 @@ This tutorial focuses on deploying a "Hello, World" Go program as a Lambda funct
         name = "lambda-hello-world-test-policy"
 
         assume_role_policy = <<EOF
-        {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-                "Service": "lambda.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-            }
+      {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+          "Action": "sts:AssumeRole",
+          "Principal": {
+              "Service": "lambda.amazonaws.com"
+          },
+          "Effect": "Allow",
+          "Sid": ""
+          }
         ]
-        }
-    EOF
+      }
+        EOF
     }
     ```
 
@@ -158,7 +158,8 @@ This tutorial focuses on deploying a "Hello, World" Go program as a Lambda funct
 2. Once you confirm your function is within that list, invoke your function!
 
    ```shell
-   aws lambda invoke --function-name=lambda-hello-world-test output.txt
+   aws lambda invoke --function-name=hello-world-test output.txt
+   cat ouput.txt # "Hello, world!"
    ```
 
 3. Congrats, you deployed your first Lambda function with Terraform!!!
@@ -181,7 +182,7 @@ Let's say you want your shiny new Lambda function to run every day. Maybe every 
 
     ```terraform
     resource "aws_cloudwatch_event_target" "cloudwatch_event_target_hello_world_lambda_test" {
-      rule = "${aws_cloudwatch_event_rule.every_hour.name}"
+      rule = "${aws_cloudwatch_event_rule.run_hello_world_lambda_every_hour_test.name}"
       target_id = "hello-world-test"
       arn = "${aws_lambda_function.hello_world_test.arn}"
     }
@@ -195,11 +196,11 @@ Let's say you want your shiny new Lambda function to run every day. Maybe every 
       action = "lambda:InvokeFunction"
       function_name = "${aws_lambda_function.hello_world_test.function_name}"
       principal = "events.amazonaws.com"
-      source_arn = "${aws_cloudwatch_event_rule.every_hour.arn}"
+      source_arn = "${aws_cloudwatch_event_rule.run_hello_world_lambda_every_hour_test.arn}"
     }
     ```
 
-4. Run our Terraform commands form the command line: `terraform plan` and `terraform apply`.
+4. Run our Terraform commands from the command line: `terraform plan` and `terraform apply`.
 
 5. Your function will now run every hour!
 

--- a/infra/getting_started/your_first_lambda_function.md
+++ b/infra/getting_started/your_first_lambda_function.md
@@ -96,7 +96,7 @@ This tutorial focuses on deploying a "Hello, World" Go program as a Lambda funct
 
     `role` is the IAM role attached to this function. We will be creating this in the next step.
 
-    `handler` is the entrypoint into the function. In this particular case, it's the `main.go` file in `.zip`.
+    `handler` is the entrypoint into the function. In this particular case, it's the `main` executable produced by `go build`.
 
     `runtime` specifies what language this function will be running in.
 


### PR DESCRIPTION
- Maintain consistency with the [AWS naming doc](https://github.com/trussworks/Engineering-Playbook/blob/master/infra/aws/naming.md)
- Add explicit language definitions to each code block
- Add some more clarifications