### PR TITLE
Feature/166057647 circleci precommit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: trussworks/circleci-docker-primary:5ca2def958c1a6abbb6ac7668c13ecee5b4598e1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+            - pre-commit-dot-cache
+      - run:
+          name: Run pre-commit tests
+          command: pre-commit run --all-files
+      - save_cache:
+          key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+          paths:
+            - ~/.cache

--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ One question we might ask is whether or not this repo should be public? My incli
 * [Infrastructure/Deployment](./infra/README.md) - DevOps, Infrastructure ... call it what you will, somehow that application needs to get out into production and been maintained once it gets there.
 * [Security](./security/README.md) - The world is not as nice as we would like it to be. What should we do about that? What should we not be afraid of, despite what people say?
 * [Templates](./templates/README.md) - "Ooh, ooh... I have a thing to add." Here's how to add to this Playbook
+
+## Initial Setup
+
+### Install Dependencies(Mac OS)
+
+    brew update
+    brew install pre-commit markdownlint
+    pre-commit install

--- a/developing/cycle/README.md
+++ b/developing/cycle/README.md
@@ -1,6 +1,7 @@
 # [Tools and Practice](../README.md) / Development Cycle
 
 ## Overview
+
 At Truss, we practice agile with a small "a". This means getting back to the basics of what it means to [develop software with agility](https://pragdave.me/blog/2014/03/04/time-to-kill-agile.html):
 
 > * Find out where you are
@@ -9,15 +10,19 @@ At Truss, we practice agile with a small "a". This means getting back to the bas
 > * Repeat
 
 In order to implement these principles, we do a few things:
+
 * Planning and executing tasks in repeated cycles, called Sprints
 * At the end of each cycle, we review our work and whether or we accomplished what we set out to do.
 
 ## Contents
+
 * [Pivotal Tracker](./tracker.md)
 
 <!---
+
 * [Sprint Planning](./planning.md)
 * [Standup](./standup.md)
 * [Demo](./demo.md)
 * [Retrospective](./retro.md)
+
 --->

--- a/developing/cycle/tracker.md
+++ b/developing/cycle/tracker.md
@@ -1,6 +1,7 @@
 # [Development Cycle](./README.md) / Pivotal Tracker
 
 ## Overview
+
 We use Pivotal Tracker to track tasks and estimate how much time each task will take.
 
 * 🔒[How to organize a Pivotal project](https://docs.google.com/document/d/1abmxQdYol6Zi3kR3U__JNJl3uPdKF9WPYWfu75AkZ50/edit#heading=h.yyb7wuihugn8)

--- a/developing/docker/README.md
+++ b/developing/docker/README.md
@@ -29,7 +29,7 @@ using the `overlay2` storage driver.
 
     $ docker info |grep Storage
     Storage Driver: overlay2
-    
+
 If you don't see overlay2, upgrading to the latest version will add
 that support, but you would need to recreate all of your docker data
 to utilize it.  The `Reset` bomb should do it.
@@ -78,7 +78,7 @@ To get a `top` like report of what your containers are doing
 To see where all your disk space is going:
 
     docker system df
-   
+
 To remove stopped containers, dangling images, the build cache and
 unused networks:
 
@@ -87,4 +87,3 @@ unused networks:
 See [the docker system prune
 documentation](https://docs.docker.com/engine/reference/commandline/system_prune/)
 for more options like pruning volumes
-

--- a/developing/eid/README.md
+++ b/developing/eid/README.md
@@ -19,6 +19,7 @@ List of editors that Truss engineers use (sorted alphabetically):
 ### Plugin suggestions
 
 #### Sublime Text
+
 * PackageControl
 * EditorConfig
 * JsPrettier (you will need to configure it to auto-format on save)
@@ -26,10 +27,12 @@ List of editors that Truss engineers use (sorted alphabetically):
 * Git
 
 #### vi(m)
+
 * [vim-prettier](github.com:prettier/vim-prettier)
 * [vim-javascript](pangloss/vim-javascript.git)
 * [editorconfig](editorconfig/editorconfig-vim.git)
 
 #### VS Code
+
 * Prettier
 * Path Intellisence

--- a/developing/languages/GO.md
+++ b/developing/languages/GO.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Go aka Golang is a programming language designed by folks at Google. 
+Go aka Golang is a programming language designed by folks at Google.
 
 ## Resources
 

--- a/developing/languages/README.md
+++ b/developing/languages/README.md
@@ -8,19 +8,20 @@ While Truss may have opinions on particular languages and strategic reasons for 
 
 ## Languages Trussels are proficient in
 
-- [Go] (./GO.md) 
-- JavaScript (including TypeScript/FlowScript)
-- Swift
-- Rust
-- Kotlin
-- Ruby
-- Python
-- Java
-- C/C++
+* [Go] (./GO.md)
+* JavaScript (including TypeScript/FlowScript)
+* Swift
+* Rust
+* Kotlin
+* Ruby
+* Python
+* Java
+* C/C++
 
 ## Language Resources
 
 ### Go
+
 If you are new to Go, these are resources that can help you get started:
 
 1. [A Tour of Go](https://tour.golang.org) (in-browser interactive language tutorial)
@@ -38,6 +39,7 @@ Additional resources:
 * _Article_: [Copying data from S3 to EBS 30x faster using Golang](https://medium.com/@venks.sa/copying-data-from-s3-to-ebs-30x-faster-using-go-e2cdb1093284)
 
 ### JavaScript
+
 Important JS patterns and features to understand:
 
 * Destructuring Assignment

--- a/infra/README.md
+++ b/infra/README.md
@@ -5,10 +5,11 @@
 Infrastructure and deployment is really important, and at all opportunities we should try to automate it.
 
 ## Getting Started
+
 - [Setting up your AWS account 🔒](https://github.com/trussworks/truss-infra#making-changes-to-aws)
-    - You will need to pair with someone that has access to AWS already to run the Terraform commands in the instructions.
+  - You will need to pair with someone that has access to AWS already to run the Terraform commands in the instructions.
 - [Your first Lambda Function 🔒](./getting_started/your_first_lambda_function.md)
-    - After you have AWS access you can deploy your first AWS Lambda Function with Go and Terraform.
+  - After you have AWS access you can deploy your first AWS Lambda Function with Go and Terraform.
 
 ## Immutable infrastructure techniques
 
@@ -16,7 +17,6 @@ Infrastructure and deployment is really important, and at all opportunities we s
 - Containers (Docker)
 - Functions as a Service (Lambda, etc)
 - [Terraform](./tf/README.md)
-
 
 ## Infrastructure as code techniques
 
@@ -32,5 +32,6 @@ Infrastructure and deployment is really important, and at all opportunities we s
 - Azure
 
 ## Resources
+
 - [Examples of common infrastructure patterns at Truss 🔒](https://github.com/trussworks/truss-infra)
 - [Terraform layout example 🔒](https://github.com/trussworks/terraform-layout-example): a basic approach Truss takes towards Terraform layout.

--- a/web/README.md
+++ b/web/README.md
@@ -5,6 +5,7 @@
 This is a really broad area. Topics range from languages and high level frameworks (Django, RoR, Golang), though specific usage patterns e.g. how best to use Redux as a data store for Flux based single page Javascript apps and down to particulars like how to manage session state in an HTTP based application.
 
 ## Contents
+
 * [Front End Guide](frontend/)
 * [Browser Support](browsersupport/)
 * [Testing](testing/)

--- a/web/browsersupport/README.md
+++ b/web/browsersupport/README.md
@@ -1,9 +1,11 @@
 # [Engineering Playbook](../../README.md) / [Web Development](../README.md) / Browser Support
 
 ## Overview
+
 Unless specifically negotiated with the client, we generally support only the latest browser versions supported by operating systems.
 
 ### Browsers for Development and Testing
+
 Suggested browsers to use for development and testing:
 
 * Latest Google Chrome

--- a/web/frontend/README.md
+++ b/web/frontend/README.md
@@ -1,51 +1,62 @@
 # [Engineering Playbook](../../README.md) / [Web Development](../README.md) / Front End Guide
 
 ## Overview
+
 These are recommendations for front end development.
 
 ### Frameworks
+
 We typically choose React as our front end framework of choice.
 
 ### Testing
 
 #### Test Runners and Libraries (for React)
-- Jest
- - If you use create-react-app, this is included.
- - Provides snapshot and DOM testing.
-- Enzyme
- - Allows you to assert and manipulate rendered components with jQuery-like selectors.
+
+* Jest
+  * If you use create-react-app, this is included.
+  * Provides snapshot and DOM testing.
+* Enzyme
+  * Allows you to assert and manipulate rendered components with jQuery-like selectors.
 
 #### Writing Tests
-- Each React component should have a test.
- - At minimum, does the component render?
- - Container components have logic in them, and that logic should be tested.
+
+* Each React component should have a test.
+  * At minimum, does the component render?
+  * Container components have logic in them, and that logic should be tested.
 
 #### Browser Testing
-- We use [Cypress](https://www.cypress.io) for most browser testing with both Chrome and headless Chrome.
+
+* We use [Cypress](https://www.cypress.io) for most browser testing with both Chrome and headless Chrome.
 
 ### Browser Extensions
+
 The following extensions can be installed to assist with debugging React and Redux applications:
 
 * [React Developer Tools](https://github.com/facebook/react-devtools#installation)
 * [Redux DevTools Extension](http://extension.remotedev.io/#redux-devtools-extension)
 
 ### Style and Formatting
+
 We generally adhere to the [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript), unless they conflict with project specific Prettier or lint rules.
 
 #### Auto-formatting
-- [Prettier](https://prettier.io) is recommended.
- - [Prettier editor integration](https://prettier.io/docs/en/editors.html) to make it easy to format and autosave.
- - Prefer single quotes for non-JSX code (CLI: `--single-quote` API: `singleQuote: true`)
- - Prefer trailing commas for cleaner PRs and error reduction (CLI: `--trailing-comma true` API: `trailingComma: true`)
- - A `.prettierrc` will be in the project for custom settings.
+
+* [Prettier](https://prettier.io) is recommended.
+  * [Prettier editor integration](https://prettier.io/docs/en/editors.html) to make it easy to format and autosave.
+  * Prefer single quotes for non-JSX code (CLI: `--single-quote` API: `singleQuote: true`)
+  * Prefer trailing commas for cleaner PRs and error reduction (CLI: `--trailing-comma true` API: `trailingComma: true`)
+  * A `.prettierrc` will be in the project for custom settings.
 
 #### Linting
-- [ESLint](https://eslint.org).
+
+* [ESLint](https://eslint.org).
 
 ### CSS
+
 Follow the BEM (Block, Element, Modifier) methodology. Also helpful to follow is the [U.S. Web Design System](https://designsystem.digital.gov/components/).
 
 ### Additional Resources
+
 Various resources on React, Redux, etc, for a variety of learning styles.
 
 * _Read_: [React Tutorial](https://reactjs.org/tutorial/tutorial.html) - Official tutorial from React. I (Alexi) personally found this cumbersome. If you stick with it you’ll learn the basics.


### PR DESCRIPTION
[#166057647](https://www.pivotaltracker.com/story/show/166057647)

Use markdownlint as a pre-commit hook and run that pre-commit in circleci to ensure the docs remain sparkly clean.

Convert the docs to markdownlint approved syntax.

Prefer `*` to `-` when a conflict is found
