### PR TITLE
update lint install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,5 @@ One question we might ask is whether or not this repo should be public? My incli
 ### Install Dependencies(Mac OS)
 
     brew update
-    brew install npm pre-commit
-    npm install -g markdownlint-cli
+    brew install pre-commit
     pre-commit install

--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ One question we might ask is whether or not this repo should be public? My incli
 ### Install Dependencies(Mac OS)
 
     brew update
-    brew install pre-commit markdownlint
+    brew install npm pre-commit
+    npm install -g markdownlint-cli
     pre-commit install


### PR DESCRIPTION
Install for `markdownlint` is via `npm` as per https://github.com/igorshubovych/markdownlint-cli (rather than via `brew`)