### PR TITLE
Breaking up CI/CD docs, adding some helpful CircleCI patterns

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -5,6 +5,7 @@
     "siblings_only": true
   },
   "MD014": false,
+  "MD033": false,
   "MD040": false,
   "MD046": false
 }

--- a/developing/cicd/README.md
+++ b/developing/cicd/README.md
@@ -4,86 +4,13 @@
 
 The release process is one of the most important parts of development
 for obvious reasons -- without a release, your code is never going to
-actually be used by anyone. This page lays out Truss's method of using
-continuous integration and continuous delivery (CI/CD) to deliver
-software to customers.
+actually be used by anyone. This section provides resources for setting
+up a continuous integration and continuous delivery (CI/CD) pipeline
+according to Truss best practices to deliver software to customers.
 
-## Developing Your Code
+## Contents
 
-Here at Truss, we generally use Git for our code repository, and Github
-more specifically. Our preferred method for making changes and integrating
-them into the project is relatively simple:
+* [Standard Development/Deployment Pipeline](./cicd-pipeline.md)
+* [CircleCI Config Patterns](./circleci-patterns.md)
 
-1. Check out the repository for `my-project`.
-2. Create a new branch `my-feature` in the repository.
-3. Make your changes to the code and commit them, then push your code to
-   the central repository.
-4. Create a pull request, get approvals, and then merge your `my-feature`
-   branch into `master`.
-
-The virtue of this workflow over more complicated methods like the one
-shown [here](https://nvie.com/posts/a-successful-git-branching-model/) is
-that we are constantly merging to `master`, so the drift of any specific
-branch from `master` is kept to a minimum. The idea of more frequent small
-changes over less frequent large changes is a fundamental aspect of many
-development practices (such as Agile). The core of this belief is that
-things which break the the application can quickly be noticed, isolated,
-and rolled back (or fixed), without requiring a lengthy period of
-diagnosis, or requiring delicate operations to pull out problem code
-without sacrificing code which is benign.
-
-This process is known as *continuous integration* or CI (because code is
-constantly being integrated into the mainline of the project). Its
-relative simplicity belies the fact that it also requires a great deal
-of additional work to ensure that this process can occur without
-disrupting the project's development.
-
-## Unit Testing
-
-Key to ensuring that our CI workflow is safe is making sure we are doing
-unit testing of our code *prior* to merging in to `master`. To do this,
-we use automated tools like CircleCI to run a battery of tests against
-every branch we create a PR from. We want to run a variety of tests that
-cover a variety of things like:
-
-* Code formatting and syntax
-* Acceptance testing for configuration
-* Functional code testing
-
-Our goal is to be as sure as possible *before* anyone even looks at the
-pull request that this code does what we want and won't break things.
-
-## Deploying Our Code
-
-Merging your code is just the first step to actually getting it in front
-of a real person to use it. The other component for this how your code
-gets from a Git repository into a live environment where someone can touch
-it. This workflow is orchestrated via an automated tool like CircleCI, and
-looks something like this:
-
-1. New code is merged into `master`.
-2. CircleCI detects that `master` has been updated and deploys the code to
-   our `development` environment.
-3. CircleCI checks to make sure the deploy was successful. Is our
-   environment running the right version of the code?
-4. CircleCI (or another tool fired by CircleCI) performs post-deployment
-   testing. Does it pass some functional tests to ensure user workflows
-   are functional (eg, can someone log in, pull up a user record, put
-   things in a shopping cart, etc)? Are logs filling up with error now
-   that the new version is deployed?
-5. If the tests pass, CircleCI goes ahead and deploys to our `production`
-   environment, then runs the same sort of tests it ran in development.
-   In some cases, there may be an additional manual approval step, or
-   this may be a deployment to a `staging` environment as an additional
-   step prior to "real" production.
-
-This means that we are constantly releasing new versions of our code to
-users -- we may deploy a dozen times a day, all with a reasonable degree
-of confidence that everything will be fine, thanks to our automated
-tests. If something doesn't work, we can stop the process (or roll back,
-if the problem is detected post-deploy), and users will be protected from
-malfunctioning code. This *requires* that we write a battery of tests at
-every stage of the release process, however.
-
-This automated workflow that allows rapid release of merged code is called
-*continuous delivery* or CD.
+## Resources

--- a/developing/cicd/cicd-pipeline.md
+++ b/developing/cicd/cicd-pipeline.md
@@ -1,0 +1,87 @@
+# Standard Development/Deployment Pipeline
+
+The following is a standardized workflow for developing and deploying our
+code using CI/CD. This is meant to be an example, not a prescriptive
+ideal; if your project needs to use a different workflow, that's fine --
+your goal should still be to provide a workflow that can support frequent
+updates, good testing, and prompt deploys.
+
+## Developing Your Code
+
+Here at Truss, we generally use Git for our code repository, and Github
+more specifically. Our preferred method for making changes and integrating
+them into the project is relatively simple:
+
+1. Check out the repository for `my-project`.
+2. Create a new branch `my-feature` in the repository.
+3. Make your changes to the code and commit them, then push your code to
+   the central repository.
+4. Create a pull request, get approvals, and then merge your `my-feature`
+   branch into `master`.
+
+The virtue of this workflow over more complicated methods like the one
+shown [here](https://nvie.com/posts/a-successful-git-branching-model/) is
+that we are constantly merging to `master`, so the drift of any specific
+branch from `master` is kept to a minimum. The idea of more frequent small
+changes over less frequent large changes is a fundamental aspect of many
+development practices (such as Agile). The core of this belief is that
+things which break the the application can quickly be noticed, isolated,
+and rolled back (or fixed), without requiring a lengthy period of
+diagnosis, or requiring delicate operations to pull out problem code
+without sacrificing code which is benign.
+
+This process is known as *continuous integration* or CI (because code is
+constantly being integrated into the mainline of the project). Its
+relative simplicity belies the fact that it also requires a great deal
+of additional work to ensure that this process can occur without
+disrupting the project's development.
+
+## Unit Testing
+
+Key to ensuring that our CI workflow is safe is making sure we are doing
+unit testing of our code *prior* to merging in to `master`. To do this,
+we use automated tools like CircleCI to run a battery of tests against
+every branch we create a PR from. We want to run a variety of tests that
+cover a variety of things like:
+
+* Code formatting and syntax
+* Acceptance testing for configuration
+* Functional code testing
+
+Our goal is to be as sure as possible *before* anyone even looks at the
+pull request that this code does what we want and won't break things.
+
+## Deploying Our Code
+
+Merging your code is just the first step to actually getting it in front
+of a real person to use it. The other component for this how your code
+gets from a Git repository into a live environment where someone can touch
+it. This workflow is orchestrated via an automated tool like CircleCI, and
+looks something like this:
+
+1. New code is merged into `master`.
+2. CircleCI detects that `master` has been updated and deploys the code to
+   our `development` environment.
+3. CircleCI checks to make sure the deploy was successful. Is our
+   environment running the right version of the code?
+4. CircleCI (or another tool fired by CircleCI) performs post-deployment
+   testing. Does it pass some functional tests to ensure user workflows
+   are functional (eg, can someone log in, pull up a user record, put
+   things in a shopping cart, etc)? Are logs filling up with error now
+   that the new version is deployed?
+5. If the tests pass, CircleCI goes ahead and deploys to our `production`
+   environment, then runs the same sort of tests it ran in development.
+   In some cases, there may be an additional manual approval step, or
+   this may be a deployment to a `staging` environment as an additional
+   step prior to "real" production.
+
+This means that we are constantly releasing new versions of our code to
+users -- we may deploy a dozen times a day, all with a reasonable degree
+of confidence that everything will be fine, thanks to our automated
+tests. If something doesn't work, we can stop the process (or roll back,
+if the problem is detected post-deploy), and users will be protected from
+malfunctioning code. This *requires* that we write a battery of tests at
+every stage of the release process, however.
+
+This automated workflow that allows rapid release of merged code is called
+*continuous delivery* or CD.

--- a/developing/cicd/circleci-patterns.md
+++ b/developing/cicd/circleci-patterns.md
@@ -1,0 +1,155 @@
+# CircleCI Config Patterns
+
+At Truss, CircleCI tends to be our CI/CD tool of choice. In order to help
+developers and infrastructure engineers get their pipelines working quickly,
+there are some patterns you can use to make your pipeline more robust.
+
+## Split Build/Push Steps
+
+If you are building a pipeline that builds docker images and then deploys
+them to multiple repositories, you can save the built image to the CircleCI
+workspace, then load it via another. You will have two commands, a build
+command and a push command, and you'll run the build job once, and a push
+job for each repository.
+
+<details>
+  <summary>Build/Push Config Pattern</summary>
+
+  ```yaml
+  commands:
+    build_image:
+      parameters:
+        dockerfile:
+          type: string
+        image_name:
+          type: string
+        tag:
+          type: string
+      steps:
+        - run:
+            name: 'Build docker image'
+            command: |
+              docker build -f << parameters.dockerfile >> -t << parameters.image_name >>:<< parameters.tag >> .
+              mkdir -p workspace
+              docker save -o workspace/<< parameters.image_name >> << parameters.image_name >>:<< parameters.tag >>
+        - persist_to_workspace:
+            root: workspace
+            paths:
+              - << parameters.image_name >>
+
+    push_image:
+      parameters:
+        image_name:
+          type: string
+        tag:
+          type: string
+        repo:
+          type: string
+      steps:
+        - attach_workspace:
+            at: /tmp/workspace
+        - run:
+            name: 'Retrieve docker image from workspace'
+            command: |
+              docker load -i /tmp/workspace/<< parameters.image_name >>
+        - run:
+            name: 'Tag and push docker image'
+            command: |
+              bash -c "$(aws ecr get-login --no-include-email --region $AWS_REGION)"
+              docker tag << parameters.image_name >>:<< parameters.tag >> ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/<< parameters.repo >>:git-commit-${CIRCLE_SHA1}
+              docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/<< parameters.repo >>:git-commit-${CIRCLE_SHA1}
+
+  jobs:
+    build:
+      executor: main
+      steps:
+        - checkout
+        - setup_remote_docker:
+            # You can set docker_layer_caching to true if you have a paid plan
+            docker_layer_caching: false
+        - make bin_linux/my_app
+        - build_image:
+            dockerfile: Dockerfile
+            image_name: my_app
+            tag: latest
+
+    push:
+      executor: main
+      steps:
+        - setup_remote_docker:
+            # You can set docker_layer_caching to true if you have a paid plan
+            docker_layer_caching: false
+        - push_image:
+            image_name: my_app
+            tag: latest
+            repo: app-my_app
+  ```
+
+</details>
+
+Reference: [Build Docker image in one job and use in another job](https://support.circleci.com/hc/en-us/articles/360019182513-Build-Docker-image-in-one-job-and-use-in-another-job)
+
+## Multiple Account Operations
+
+With the use of AWS Organizations, it's not uncommon that we want CircleCI
+to execute steps in different AWS accounts. You can update AWS credentials
+and variables by saving multiple versions of the environment variables in
+CircleCI, and then using commands to swap between them. See the example
+code below:
+
+<details>
+  <summary>Multiple AWS Account Credentials Pattern</summary>
+
+  ```yaml
+    commands:
+      aws_vars_dev:
+        steps:
+          - run:
+              name: 'Setting up AWS environment variables for dev'
+              command: |
+                echo "export AWS_REGION=$DEV_REGION" >> $BASH_ENV
+                echo "export AWS_ACCOUNT_ID=$DEV_ACCOUNT_ID" >> $BASH_ENV
+                echo "export AWS_ACCESS_KEY_ID=$DEV_ACCESS_KEY" >> $BASH_ENV
+                echo "export AWS_SECRET_ACCESS_KEY=$DEV_SECRET_ACCESS_KEY" >> $BASH_ENV
+
+      aws_vars_prod:
+        steps:
+          - run:
+              name: 'Setting up AWS environment variables for prod'
+              command: |
+                echo "export AWS_REGION=$PROD_REGION" >> $BASH_ENV
+                echo "export AWS_ACCOUNT_ID=$PROD_ACCOUNT_ID" >> $BASH_ENV
+                echo "export AWS_ACCESS_KEY_ID=$PROD_ACCESS_KEY" >> $BASH_ENV
+                echo "export AWS_SECRET_ACCESS_KEY=$PROD_SECRET_ACCESS_KEY" >> $BASH_ENV
+
+    jobs:
+      do_thing_dev:
+        executor: main
+        steps:
+          - aws_vars_dev
+          - do_thing:
+              environment: dev
+
+      do_thing_prod:
+        executor: main
+        steps:
+          - aws_vars_prod
+          - do_thing:
+              environment: prod
+  ```
+
+</details>
+
+Reference: [Using `BASH_ENV` to set environment variables](https://circleci.com/docs/2.0/env-vars/#using-bash_env-to-set-environment-variables)
+
+## Manual Approval by Restricted Groups
+
+If you need to gate part of your CI/CD pipeline to a small group (for
+example, you want only product managers to be able to approve deploys to
+your production environment), you can use a CircleCI restricted context
+to achieve this. You will need to create a GitHub team for the people you
+want to be able to approve these jobs, create a context in the CircleCI
+UI that includes this team only, and then add the context to all jobs
+*after* the approval job.
+
+Reference: [CircleCI Contexts](https://circleci.com/docs/2.0/contexts/)


### PR DESCRIPTION
I thought I'd add some of the patterns I've found over the course of working in SABER to the Engineering Playbook so people would have some reference to use without needing access to project-specific repos. Did a little messing with the CICD organization to support that.