### PR TITLE
Document use of pre-commit templateDir

### DIFF
--- a/developing/vcs/README.md
+++ b/developing/vcs/README.md
@@ -202,6 +202,23 @@ Resolves #123
 
 We use [pre-commit](https://pre-commit.com/) at Truss to easily add git hooks to our Git repos. This allows us to automate things like checking for merge conflicts or mistakenly adding secret keys in our code. See [this example](https://github.com/trussworks/circleci-docker-primary/blob/master/.pre-commit-config.yaml) pre-commit config file from one of our projects.
 
+Since git does not distribute hooks when a repository is cloned, you will have
+to install pre-commit in each cloned repo manually using
+`pre-commit install --install-hooks` or pre-commit will not run in that repo.
+To assist with automating this step, pre-commit has a [feature] to exploit the
+[template directory] setting in git:
+
+```console
+git config --global init.templateDir ~/.git-template
+pre-commit init-templatedir ~/.git-template
+```
+
+From now on, each new repository you create or clone will have pre-commit
+installed automatically.
+
+[feature]: https://pre-commit.com/#pre-commit-init-templatedir
+[template directory]: https://git-scm.com/docs/git-init#_template_directory
+
 ### pre-reqs
 
 > A tool to check your project prerequisites so your engineers don't have to.


### PR DESCRIPTION
I discovered this trick when reading through pre-commit docs a few weeks ago. It has served me well since.