### PR TITLE
Fixing a contradictory sentence in org bootstrap

### DIFF
--- a/infra/aws/org-bootstrap.md
+++ b/infra/aws/org-bootstrap.md
@@ -143,7 +143,7 @@ resource "aws_iam_role_policy_attachment" "admin_administrator_access" {
 Once you have applied the Terraform and have the users created, issue
 security keys for this user and add them to aws-vault; change your
 profile for this account to use these new credentials and delete the
-root credentials from both your aws-vault and the `org-root` account. You
+temporary user from your aws-vault and the `org-root` account. You
 should not use the root account anymore unless there is some kind of
 emergency.
 


### PR DESCRIPTION
This fixes a confusing paragraph; originally I had suggested people use the root account to bootstrap the org-root account, but I changed it to use a temporary user, but didn't fix that in another part of the guide.