### PR TITLE
remove refs to iam-cross-acct-src in organization & bootstrap files

### DIFF
--- a/infra/aws/aws-organizations.md
+++ b/infra/aws/aws-organizations.md
@@ -64,9 +64,7 @@ description of the patterns we've adopted.
   account. *This cannot be changed once the account is created, so be sure
   to do it now.*
 * To access other accounts, we assign group policies which allow direct role assumption.
-  See the [terraform-layout-example](https://github.com/trussworks/terraform-layout-example)
-  and [terraform-aws-iam-cross-acct-dest](https://github.com/trussworks/terraform-aws-iam-cross-acct-dest)
-  modules for the way we do this.
+  See the [terraform-aws-iam-cross-acct-dest](https://github.com/trussworks/terraform-aws-iam-cross-acct-dest) modules for the way we do this. See [`terraform-layout-example`](https://github.com/trussworks/terraform-layout-example) for an example of how this is done.
 * Like the `org-root` account, other than the IAM users and groups, we
   should avoid putting any other resources in this account.
 

--- a/infra/aws/aws-organizations.md
+++ b/infra/aws/aws-organizations.md
@@ -64,7 +64,7 @@ description of the patterns we've adopted.
   account. *This cannot be changed once the account is created, so be sure
   to do it now.*
 * To access other accounts, we assign group policies which allow direct role assumption.
-  See the [terraform-aws-iam-cross-acct-dest](https://github.com/trussworks/terraform-aws-iam-cross-acct-dest) modules for the way we do this. See [`terraform-layout-example`](https://github.com/trussworks/terraform-layout-example) for an example of how this is done.
+  We use [`iam-user-group`](https://registry.terraform.io/modules/trussworks/iam-user-group/aws/1.0.2) and [`iam-cross-acct-dest`](https://registry.terraform.io/modules/trussworks/iam-cross-acct-dest/aws) modules to do this; see [`terraform-layout-example`](https://github.com/trussworks/terraform-layout-example) for how we use them.
 * Like the `org-root` account, other than the IAM users and groups, we
   should avoid putting any other resources in this account.
 

--- a/infra/aws/aws-organizations.md
+++ b/infra/aws/aws-organizations.md
@@ -63,9 +63,8 @@ description of the patterns we've adopted.
   billing data without having to give them direct access to the `org-root`
   account. *This cannot be changed once the account is created, so be sure
   to do it now.*
-* To access other accounts, users will use access keys in this account,
-  then assume a role in another account that allows access from this one.
-  See the [terraform-aws-iam-cross-acct-src](https://github.com/trussworks/terraform-aws-iam-cross-acct-src)
+* To access other accounts, users will use MISTY TODO: [their own ids? - get exact wording](link).
+  See the [terraform-layout-example](https://github.com/trussworks/terraform-layout-example)
   and [terraform-aws-iam-cross-acct-dest](https://github.com/trussworks/terraform-aws-iam-cross-acct-dest)
   modules for the way we do this.
 * Like the `org-root` account, other than the IAM users and groups, we

--- a/infra/aws/aws-organizations.md
+++ b/infra/aws/aws-organizations.md
@@ -63,7 +63,7 @@ description of the patterns we've adopted.
   billing data without having to give them direct access to the `org-root`
   account. *This cannot be changed once the account is created, so be sure
   to do it now.*
-* To access other accounts, users will use MISTY TODO: [their own ids? - get exact wording](link).
+* To access other accounts, we assign group policies which allow direct role assumption.
   See the [terraform-layout-example](https://github.com/trussworks/terraform-layout-example)
   and [terraform-aws-iam-cross-acct-dest](https://github.com/trussworks/terraform-aws-iam-cross-acct-dest)
   modules for the way we do this.

--- a/infra/aws/org-bootstrap.md
+++ b/infra/aws/org-bootstrap.md
@@ -287,7 +287,7 @@ Follow the same steps you took to bootstrap the `org-root` account to
 bootstrap your `id` account. Once you've done that, you can set up the
 users and groups that team members will use to access all other AWS
 resources. Truss has made two modules which will help you get this done,
-[`iam-cross-acct-src`](https://registry.terraform.io/modules/trussworks/iam-cross-acct-src/aws) and
+[`terraform-layout-example`](https://github.com/trussworks/terraform-layout-example) and
 [`iam-cross-acct-dest`](https://registry.terraform.io/modules/trussworks/iam-cross-acct-dest/aws).
 
 In order to do this, in your `id` account, define your users and then

--- a/infra/aws/org-bootstrap.md
+++ b/infra/aws/org-bootstrap.md
@@ -286,9 +286,7 @@ you can use the profile pattern described in the next section.
 Follow the same steps you took to bootstrap the `org-root` account to
 bootstrap your `id` account. Once you've done that, you can set up the
 users and groups that team members will use to access all other AWS
-resources. Truss has made two modules which will help you get this done,
-[`terraform-layout-example`](https://github.com/trussworks/terraform-layout-example) and
-[`iam-cross-acct-dest`](https://registry.terraform.io/modules/trussworks/iam-cross-acct-dest/aws).
+resources. Truss uses [`terraform-aws-iam-user-group`](https://github.com/trussworks/terraform-aws-iam-user-group) and [`iam-cross-acct-dest`](https://registry.terraform.io/modules/trussworks/iam-cross-acct-dest/aws) modules to do this; see [`terraform-layout-example`](https://github.com/trussworks/terraform-layout-example) for how this is done.
 
 In order to do this, in your `id` account, define your users and then
 use the module like so:

--- a/infra/aws/org-bootstrap.md
+++ b/infra/aws/org-bootstrap.md
@@ -286,7 +286,7 @@ you can use the profile pattern described in the next section.
 Follow the same steps you took to bootstrap the `org-root` account to
 bootstrap your `id` account. Once you've done that, you can set up the
 users and groups that team members will use to access all other AWS
-resources. Truss uses [`terraform-aws-iam-user-group`](https://github.com/trussworks/terraform-aws-iam-user-group) and [`iam-cross-acct-dest`](https://registry.terraform.io/modules/trussworks/iam-cross-acct-dest/aws) modules to do this; see [`terraform-layout-example`](https://github.com/trussworks/terraform-layout-example) for how this is done.
+resources. Truss uses [`iam-user-group`](https://registry.terraform.io/modules/trussworks/iam-user-group/aws/1.0.2) and [`iam-cross-acct-dest`](https://registry.terraform.io/modules/trussworks/iam-cross-acct-dest/aws) modules to do this; see [`terraform-layout-example`](https://github.com/trussworks/terraform-layout-example) for how we use them.
 
 In order to do this, in your `id` account, define your users and then
 use the module like so:


### PR DESCRIPTION
# [Tracker story](https://www.pivotaltracker.com/story/show/172678964)

Changes proposed in this pull request:

-  removes refs to `iam-cross-acct-src` which will be archived
