### PR TITLE
Updating password guidance on org-root accounts to match proposed ADR

### DIFF
--- a/infra/aws/aws-organizations.md
+++ b/infra/aws/aws-organizations.md
@@ -51,6 +51,9 @@ description of the patterns we've adopted.
   product or delivery managers (with their accounts in the ID account)
   to give them access to billing information *without* giving them access
   to this account directly.
+* The `root` password for this account should be reset each time an admin
+  leaves the project or at least once every six months, just to ensure
+  that it is not leaked.
 
 ### The ID Account
 

--- a/infra/aws/govcloud.md
+++ b/infra/aws/govcloud.md
@@ -23,8 +23,8 @@ security and compliance standards needed to meet federal guidelines like
   you place on all IAM users. This means setting password expiration to
   a very short period (as is common in some of our commercial AWS
   environments) can lock you out of the `Administrator` user; since we
-  can get console access via role assumption, we recommend not having the
-  password expiration on in at least the GovCloud org-root account and
+  can get console access via role assumption, we recommend setting the
+  password expiration on the GovCloud org-root account to six months and
   instead treating this user as you would the `root` user in commercial
   AWS (ie, do not use it for anything other than bootstrapping or
   "break glass" cases).


### PR DESCRIPTION
This just tweaks the guidance around root and Administrator passwords in our AWS accounts to match the proposed ADR from our discussion yesterday.