### PR TITLE
Incident response section start

### DIFF
--- a/developing/README.md
+++ b/developing/README.md
@@ -21,7 +21,6 @@ Generally, our approach should be "if there is a suggestion or answer in these p
 * [Defects/Bugs](./bugs/README.md)
 * [Technical Design](./technical-design/README.md)
 * [Code Reviews](./code-reviews/README.md)
-* [On-Call Best Practices](./on-call/README.md)
 * [Slack Best Practices](./slack/README.md)
 * [Growth on Client](./growth/README.md)
 * [Learning Resources](./learning/README.md)

--- a/incident-response/README.md
+++ b/incident-response/README.md
@@ -12,4 +12,6 @@ with the post-incident retrospective (aka postmortem) process.
 
 * [On-Call Best Practices](./on-call.md)
 * [Incident Response Overview](./overview.md)
+* [Security Incident Response](./security-incidents.md)
+* [Incident Analysis and Retrospectives](./analysis.md)
 * [External-Resources](./external-resources.md)

--- a/incident-response/README.md
+++ b/incident-response/README.md
@@ -1,0 +1,15 @@
+# [Engineering Playbook](../README.md) / Incident Response
+
+## Overview
+
+Incident response is an important part of maintaining a reliable, secure
+service. There are a number of components to incident response, starting
+with how we prepare for incidents with on-call, through the actual process
+of responding to service or security incidents, to how we follow through
+with the post-incident retrospective (aka postmortem) process.
+
+## Contents
+
+* [On-Call Best Practices](./on-call.md)
+* [Incident Response Overview](./overview.md)
+* [External-Resources](./external-resources.md)

--- a/incident-response/analysis.md
+++ b/incident-response/analysis.md
@@ -1,8 +1,8 @@
 # [Incident Response](./README.md) / Incident Analysis and Retrospectives
 
 Once an incident has ended, we want to perform an analysis and conduct a
-retrospective to figure out what we can learn from what happened. It is
-important that we remember that **the primary purpose of any retrospective
-is learning, *not* necessarily fixing.**
+blameless retrospective to figure out what we can learn from what happened.
+It is important that we remember that **the primary purpose of any
+retrospective is learning, *not* necessarily fixing.**
 
 [This is a stub and needs to be expanded.]

--- a/incident-response/analysis.md
+++ b/incident-response/analysis.md
@@ -1,0 +1,8 @@
+# [Incident Response](./README.md) / Incident Analysis and Retrospectives
+
+Once an incident has ended, we want to perform an analysis and conduct a
+retrospective to figure out what we can learn from what happened. It is
+important that we remember that **the primary purpose of any retrospective
+is learning, *not* necessarily fixing.**
+
+[This is a stub and needs to be expanded.]

--- a/incident-response/external-resources.md
+++ b/incident-response/external-resources.md
@@ -1,0 +1,60 @@
+# [Incident Response](./README.md) / External Resources
+
+This is a collection of external resources that may be useful for learning
+more about elements of incident response. Please feel free to submit PRs
+to add new resources if you find something particularly interesting.
+
+## Incident Response Procedures
+
+### Articles
+
+* [PagerDuty Incident Response Guide](https://response.pagerduty.com/)
+  This is the full (slightly sanitized) version of PagerDuty's internal
+  incident response documentation, and it is very comprehensive. It is
+  an excellent resource for seeing how to apply our general principles
+  to a specific service.
+
+### Talks and Videos
+
+* [nrrd 911 ic me: The Incident Commander Role](https://www.usenix.org/node/195653)
+  This is a talk by Alice Goldfuss from SRECon 2015 where she talked
+  about the incident response process at New Relic; this includes a
+  discussion of severity levels and how they used a chatbot to
+  automate elements of the process.
+
+### Books
+
+* [Incident Management for Operations](http://shop.oreilly.com/product/0636920036159.do)
+  This is a book that talks about how to apply the ICS system to
+  IT operations; it is a good introduction to the topic and
+  describes how this actually looks in practice.
+
+## Incident Retrospectives (aka Postmortems)
+
+### Articles
+
+* [Each Necessary, But Only Jointly Sufficient](https://www.kitchensoap.com/2012/02/10/each-necessary-but-only-jointly-sufficient/)
+  This 2012 blog post from John Allspaw provides a short description of
+  why the idea of a "root cause" is a fundamentally flawed idea, and why
+  *learning* must be the driving force behind incident analysis, not fixing.
+* [The Infinite Hows](https://www.oreilly.com/radar/the-infinite-hows/)
+  This article by John Allspaw talks about the issues with the
+  commonly used "Five Whys" system of incident analysis, and does an
+  excellent job providing an overview of an alternative approach.
+
+### Talks and Videos
+
+* [Incidents As We Imagine Them Versus How They Actually Are](https://www.youtube.com/watch?v=8DtzmV1jiyQ)
+  This is a talk by John Allspaw at PagerDuty Summit 2018 which is an
+  excellent summary of the thorny issues around doing incident response
+  and how what actually happened often gets oversimplified in a desire
+  to make incidents fit in standardized boxes. If you watch nothing else
+  about incident analysis, watch this.
+
+### Books
+
+* [The Field Guide to Understanding Human Error](https://www.amazon.com/Field-Guide-Understanding-Human-Error-ebook-dp-B00BL0OZ0E/dp/B00BL0OZ0E/)
+  This one of the best texts for incident analysis, written by Sidney
+  Dekker, a leader in the field. While not specifically about software
+  services, the guidance in this book is applicable to almost any
+  technical system.

--- a/incident-response/external-resources.md
+++ b/incident-response/external-resources.md
@@ -37,6 +37,10 @@ to add new resources if you find something particularly interesting.
   This 2012 blog post from John Allspaw provides a short description of
   why the idea of a "root cause" is a fundamentally flawed idea, and why
   *learning* must be the driving force behind incident analysis, not fixing.
+* [Etsy Debriefing Facilitation Guide](https://github.com/etsy/DebriefingFacilitationGuide)
+  This is the incident retrospective guide used by Etsy and open-sourced
+  in 2016; it's an excellent resource for conducting your own debriefings
+  and the basis for a lot of similar guides throughout the industry.
 * [The Infinite Hows](https://www.oreilly.com/radar/the-infinite-hows/)
   This article by John Allspaw talks about the issues with the
   commonly used "Five Whys" system of incident analysis, and does an

--- a/incident-response/on-call.md
+++ b/incident-response/on-call.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / On-Call Best Practices
+# [Incident Response](../README.md) / On-Call Best Practices
 
 ## Overview
 
@@ -14,7 +14,7 @@ For the sake of argument, most of this article assumes you will be using
 [PagerDuty](https://www.pagerduty.com) for handling the actual alerting
 of the engineers on-call; if you are using another provider, most of these
 recommendations can be adapted for them. You can read more about various
-alerting providers in the [Alert Providers](../../infra/alerting/alert-providers.md)
+alerting providers in the [Alert Providers](../infra/alerting/alert-providers.md)
 guide.
 
 ## Definition of Terms
@@ -40,7 +40,7 @@ that determines who is on-call at any one time.
   final link in the chain. During the shift, the primary is expected to
   respond to all alerts; the secondary and tertiary are there if for some
   reason they are unable to respond (see [Escalation and Notification
-  Policies](./README.md#escalation-and-notification-policies) to see how
+  Policies](./on-call.md#escalation-and-notification-policies) to see how
   this is accomplished).
 * The secondary and tertiary also exist as additional resources for the
   primary to call in as first points of contact for assistance if they
@@ -91,14 +91,14 @@ you are expected to fulfill.
   five minutes. This means that you have *acknowledged* the alert and are
   looking into the issue. Acknowledging the alert prevents it from
   automatically escalating (see [Escalation and Notification
-  Policies](./README.md#escalation-and-notification-policies) for
+  Policies](./on-call.md#escalation-and-notification-policies) for
   more information) and communicates that you are working on the issue.
   Do not forget to do this before you start working; there's nothing
   worse than getting a page as a secondary at an odd hour only to find
   that someone else is already taking care of the problem. While this five
   minute window may seem tight, alerts should be well-tuned so that you
   are not paged for things which are not urgent (see [Project
-  Expectations](./README.md#project-expectations)).
+  Expectations](./on-call.md#project-expectations)).
 * The response time expectation does mean that your flexibility to take
   care of things away from internet access will be curtailed while on-call,
   but we want to reduce that burden as much as possible. If you need to

--- a/incident-response/overview.md
+++ b/incident-response/overview.md
@@ -1,0 +1,198 @@
+# [Incident Response](./README.md) / Overview
+
+Incident response for production systems owes a great deal to the incident
+response process developed by the National Forest Service and later
+standardized by DHS for all emergency services, known as the [Incident
+Command System (ICS)](https://en.wikipedia.org/wiki/Incident_Command_System).
+This document will describe how we adopt this process to work for our
+projects.
+
+## What Is An Incident
+
+Before we describe incident response, we should define what exactly
+constitutes an incident. An incident is a service disruption, usually
+with user impact, that needs to be addressed outside of the normal
+sprint process, and requires an increased degree of coordination and
+communication.
+
+This definition is intentionally vague because there's no hard and fast
+rule about what qualifies for the incident response process. Basically,
+if the initial responders think this framework will be useful in taking
+care of the problem, they should invoke the incident response process.
+
+## Roles
+
+### Incident Commander
+
+The incident commander runs the incident response. This *does not* mean
+that they are leading the investigation; in fact, they should not be
+investigating at all directly. Their responsiblities are:
+
+* Keep track of the current state of the incident response; what is the
+  impact to the service and users? What is the state of any mitigations
+  or attempted fixes? How are the other members of the incident response
+  team holding up?
+* Make any final decisions about incident response. No one should put in
+  place any mitigations, attempted solutions, or active diagnostic
+  measures *without* running it by the IC first. This is imperative to
+  ensure no one is working at cross purposes and that the current state
+  of the system is understood.
+
+During especially severe incidents, the commander may also have a deputy
+to assist with their tasks.
+
+### Technical Lead/Investigator
+
+There may be one or more investigators on any one incident. These are the
+people responsible for actual diagnosis of problems and implementation of
+any mitigations or attempted fixes for the cause of the incident.
+
+If there is more than two investigators on the incident, one should be
+designated as the technical lead. This will be the person who reports to
+the incident commander and coordinates the investigation to keep people
+from duplicating effort or stepping on each other's toes.
+
+Before taking any *active* measures to investigate, the investigator(s)
+should coordinate with the incident commander to make sure they are aware
+and approve of taking the action.
+
+### Communicator
+
+The communicator is responsible for handling external communication during
+the incident, both by keeping the rest of the engineering team informed
+and notifying stakeholders (such as clients) about the status of the
+incident. Similarly, if non-responders want to ask questions or notify
+the incident response team of issues, they should use the communicator as
+a conduit to the incident commander, not talk to the commander directly.
+
+During less severe incidents, the communicator role may be folded into
+the scribe role.
+
+### Scribe
+
+The scribe is responsible for recording what is going on during the
+incident, both so that the incident response team has something they can
+reference during the incident, and for the use of the person coordinating
+the retrospective after the incident is over. While most communication
+during the incident should be taking place somewhere it can be easily
+recorded (such as Slack), parsing through hundreds or thousands of Slack
+messages to find the one that is important can be difficult. The scribe
+should highlight notable events in the incident process, such as:
+
+* when the incident is first noticed
+* when the incident response begins and ends
+* when the impact of the incident changes (for the better or worse, or
+  new symptoms appear)
+* when mitigations or attempted fixes are applied
+* any other events that have a significant impact on the progress of the
+  incident
+
+These should be recorded somewhere easily available to the rest of the
+team; a Google Doc is usually the best place, since it can be added to
+or commented on collaboratively.
+
+## Severity
+
+Incidents are usually graded on a 3-5 point scale, with SEV1 being the
+most severe type of incident. This may be decided on a project-by-project
+basis, since clients may have specific reporting requirements around
+certain incident severities. In general, the severity index should look
+something like this:
+
+* SEV1 - Complete service outage or major security incident. Requires an
+  immediate response at the highest priority.
+  *Example: Service containers stuck in a crash loop, PII data known to
+  have leaked.*
+* SEV2 - Significant service degradation or severe known security
+  vulnerability. Requires an immediate response at high priority.
+  *Example: 20% HTTP error rate, library with known remote exploit in
+  use.*
+* SEV3 - Service is in a degraded state but is not currently impacting
+  users. If further issues occur, is in danger of reaching SEV1 or SEV2.
+  Should be addressed promptly, but not necessarily immediately.
+  *Example: One member of a database replica pair is down.*
+
+Additional severity levels are left to the project's discretion.
+
+## Process
+
+### Starting the Process
+
+An incident begins with someone being notified of an issue, usually by
+monitoring or a user complaint. The initial responder then notifies the
+rest of the team in an appropriate channel (projects should have their
+own channel designated for incident coordination) and begins the
+incident response.
+
+Immediately after declaring the incident, the responder should find an
+incident commander. This could be the initial responder, but they may be
+better suited for taking the lead investigator role if they have already
+started trying to diagnose the problem. If they are going to be the
+incident commander, they should find someone (such as the secondary
+on-call) to take the lead on the investigation.
+
+The incident commander should then find a scribe and communicator. For
+smaller incidents, this could be one person. The initial responder should
+give the scribe as much context to begin recording the opening stages of
+the incident, and the scribe should start the incident record and make a
+link to the document available to responders.
+
+### During the Incident
+
+The incident response team's priorities during the incident should be
+as follows:
+
+* Assess the impact of the incident (affecting random 10% of users, the
+  us-west-2 region, users whose accounts were created today, etc)
+* Mitigate the impact to the service (failing over to another region,
+  placing the service into read-only mode, rolling back to a previous
+  known good version, etc)
+* Attempt to diagnose the problem via passive measures (reading logs,
+  probing read-only endpoints, examining metrics, etc)
+* Take active measures to diagnose the problem (pushing config or code
+  changes, submitting data to see how the system responds, etc)
+* Take action in an attempt to resolve the problem.
+
+The response process during the incident should basically be a 15-20
+minute loop that looks something like this:
+
+* The technical lead or investigators report to the incident commander
+  on the current state of the service. Special attention should be paid
+  to changes in status (it is getting better or worse, affecting a new
+  set of users, spreading to another region, etc).
+* The team reviews the status of any mitigation or solution efforts that
+  were put in place during the previous iteration of the loop.
+* If the incident is not yet resolved, the team determines what their
+  course of action will be for the next 15-20 minutes; any new active
+  measures need to be approved by incident commander.
+* Team members go back and take their appropriate actions, and start
+  the loop over again in 15-20 minutes.
+
+In general, you do not want to repeat this loop in less than 15 minutes,
+otherwise your team members will be too busy checking in to actually do
+what they need to. Repeating less often means that the situation can
+change too much between check-ins, which is bad for the incident
+commander's situational awareness.
+
+If the incident is resolved, it's usually a good idea to wait an
+additional 15 minutes before you disband the response team, just to
+make sure it's *actually* resolved, and not just a temporary blip. If
+things are quiet after that, you can move to the post-incident steps.
+
+### After the Incident
+
+Once the incident is over, the incident commander should wind down the
+incident response and notify the rest of the engineering team and any
+stakeholders that the incident response is ending.
+
+Each member of the team should review the incident record and make sure
+that any of their own notes are in the record. The scribe should reread
+the log of incident communication and make sure they have highlighted
+the important events in the record.
+
+The incident commander should create a ticket to generate a retrospective
+and add links to the incident record as well as the first Slack message
+that started the incident so that the facilitator for the retrospective
+can review it. They should also find someone (if at all possible, someone
+who was *not* involved in the incident directly themselves) to facilitate
+the retrospective and assign the ticket to them.

--- a/incident-response/overview.md
+++ b/incident-response/overview.md
@@ -168,11 +168,11 @@ minute loop that looks something like this:
 * Team members go back and take their appropriate actions, and start
   the loop over again in 15-20 minutes.
 
-In general, you do not want to repeat this loop in less than 15 minutes,
-otherwise your team members will be too busy checking in to actually do
-what they need to. Repeating less often means that the situation can
-change too much between check-ins, which is bad for the incident
-commander's situational awareness.
+In general, you do not want to repeat this loop in more often than once
+every 15 minutes, otherwise your team members will be too busy checking
+in to actually do what they need to. Repeating less often means that the
+situation can change too much between check-ins, which is bad for the
+incident commander's situational awareness.
 
 If the incident is resolved, it's usually a good idea to wait an
 additional 15 minutes before you disband the response team, just to

--- a/incident-response/security-incidents.md
+++ b/incident-response/security-incidents.md
@@ -1,0 +1,9 @@
+# [Incident Response](./README.md) / Security Incidents
+
+While security incidents are similar to service-impacting incidents
+in many ways, they also have a unique set of challenges that we need
+to navigate. This document will outline how to approach security
+incidents in general; individual projects will likely have additional
+reporting requirements based on client needs.
+
+[This is a stub and needs to be expanded.]


### PR DESCRIPTION
So, this is just a start for the incident response section, and I'm not sure I'm *entirely* happy with this, but I wanted to get something there and I figure we can build on it later.

The big thing I think we're missing here is something on incident retrospectives; I thought we had a document somewhere in the Google Drive about this that I was going to use, but I can't find it now. I also think the Etsy Debriefing Guide is a pretty good place to start, but I thought about trying to put together something a little shorter. I've never actually been through an incident retrospective here either, so I am not sure what our usual process is. As a result I decided to leave it out for now and revisit it later -- I did add a bunch of my favorite articles/talks/etc on the topic to the external resources page.

I also moved the on-call guidance document here, since this seemed like a better place than the development section.