### PR TITLE
Reorganizing govcloud info, adding govcloud ACM guide

### DIFF
--- a/infrasec/aws/README.md
+++ b/infrasec/aws/README.md
@@ -12,5 +12,5 @@ This section should have some notes about why we like AWS as our default choice 
 * IAM and how to use it (capture our opinions on the use of Policies, Roles)
 * Environments throughout the product deployment cycle (notes about Dev, Test, Staging and Production)
 * [Resource Naming](./naming.md)
-* [Working in GovCloud](./govcloud.md)
+* [Working in GovCloud](./govcloud/README.md)
 * [GuardDuty in Organizations](./guardduty.md)

--- a/infrasec/aws/aws-organizations.md
+++ b/infrasec/aws/aws-organizations.md
@@ -40,7 +40,7 @@ description of the patterns we've adopted.
 * Create a `suspended` OU for the organization in this account which
   you can place accounts into if you think they have been compromised
   or are exhibiting strange behavior. It can also be used for dummy
-  accounts for [GovCloud](./govcloud.md) deployments.
+  accounts for [GovCloud](./govcloud/README.md) deployments.
 * To bootstrap other accounts, you can define them here with the
   [`aws_organizations_account`](https://www.terraform.io/docs/providers/aws/r/organizations_account.html)
   Terraform resource. Once they are created, you can access them using

--- a/infrasec/aws/govcloud/README.md
+++ b/infrasec/aws/govcloud/README.md
@@ -1,0 +1,85 @@
+# [AWS](../README.md) / Working in GovCloud
+
+Many of our government clients will want to have at least their production
+infrastructure in [AWS GovCloud](https://aws.amazon.com/govcloud-us/), which
+is a set of AWS regions that are separate from commercial AWS regions, with
+a number of additional controls that allow them to conform to the higher
+security and compliance standards needed to meet federal guidelines like
+[FedRAMP](https://www.fedramp.gov/).
+
+## GovCloud Topics
+
+* [Setting Up a GovCloud Organization](./gov-orgs.md)
+* [ACM in GovCloud](./gov-acm.md)
+
+## General Considerations With GovCloud
+
+* Every GovCloud account must be attached to a corresponding account in
+  commercial AWS (mostly for billing purposes). This has some impact on
+  how you build AWS Organizations in GovCloud (see below).
+* Commercial AWS and GovCloud resources cannot interact directly in any
+  way. This means that you cannot assume roles between the two or tie
+  a commercial resource to a GovCloud resource unless using some publicly
+  addressable method.
+* GovCloud accounts do not have a `root` user; they have an automatically
+  created IAM user named `Administrator` with full administrative
+  privileges. For most purposes, you can think of this as operating the
+  same way as the `root` user; however, it is still subject to restrictions
+  you place on all IAM users. This means setting password expiration to
+  a very short period (as is common in some of our commercial AWS
+  environments) can lock you out of the `Administrator` user; since we
+  can get console access via role assumption, we recommend setting the
+  password expiration on the GovCloud org-root account to six months and
+  instead treating this user as you would the `root` user in commercial
+  AWS (ie, do not use it for anything other than bootstrapping or
+  "break glass" cases).
+* GovCloud resources use a different AWS partition; this is the second
+  part of an ARN. So while an ARN for a commercial resource might look
+  like this:
+
+  ```text
+  arn:aws:iam::123456789000:user/testuser
+  ```
+
+  a GovCloud ARN will look like this:
+
+  ```text
+  arn:aws-us-gov:iam::123456789000:user/testuser
+  ```
+
+  This means that any Terraform modules will need to take this into
+  account; see the Terraform
+  [`aws_partition`](https://www.terraform.io/docs/providers/aws/d/partition.html)
+  data source for how to do this.
+* Many AWS services are not available in GovCloud; some are available
+  in one GovCloud region and not others. See the GovCloud
+  [Services in Scope](https://aws.amazon.com/compliance/services-in-scope/)
+  and the AWS [Region
+  Table](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/)
+  for more information.
+* Organization CloudTrails are not available in GovCloud. This means you
+  cannot add `cloudtrail.amazonaws.com` as a service principal in your
+  organization Terraform code.
+* Your first GovCloud account will have a randomly-named S3 bucket called
+  something like "cloudtrail-123456789abcedf", and all additional GovCloud
+  accounts you create via the method described in this document will have
+  a randomly-named CloudTrail and matching S3 bucket automatically created.
+  We recommend replacing these resources with your own CloudTrail pointing
+  to the AWS service logs bucket you create in the account.
+* It is not possible to enable CloudWatch Container Insights for an ECS
+  cluster. Therefore, in `aws_ecs_cluster` Terraform resources, you cannot
+  include a `setting` configuration block with `containerInsights`.
+* For Amazon RDS, GovCloud does not support `backup` or `read replica`
+  events. Therefore event notifications and subscriptions are impossible
+  for those events.
+* As of 04/20, the most up-to-date CA cert identifier for RDS instances
+  that is viable in GovCloud is `rds-ca-2017` rather than `rds-ca-2019`.
+* Because GovCloud doesn't have a root account in the traditional sense
+  (it's tied to a commerical root account), you cannot set
+  `check_root_account_mfa_enabled` to true in Truss' [AWS
+  Config](https://registry.terraform.io/modules/trussworks/config/aws)
+  module.
+* While Route53 is available in GovCloud, it is *only* available for
+  private DNS, which limits its utility somewhat. You will need to create
+  public DNS entries for your GovCloud environments in your commercial
+  AWS environment.

--- a/infrasec/aws/govcloud/gov-acm.md
+++ b/infrasec/aws/govcloud/gov-acm.md
@@ -1,0 +1,128 @@
+# [GovCloud](./README.md) / ACM in GovCloud
+
+AWS Certificate Manager (ACM) is our preferred way to handle certificates
+in AWS whenever possible. Unfortunately, due to the fact that Route53
+cannot create public DNS entries in GovCloud, the modules which create
+ACM certificates and validate them with DNS will not work. This means the
+process of creating these certificates becomes slightly more complicated.
+
+## The Problem: ACM DNS Validation
+
+In both the Truss and `terraform-aws-modules` ACM module, the module
+attempts to create three resources:
+
+* the ACM certificate
+* the Route53 DNS entry to validate the certificate
+* the Terraform [`aws_acm_certificate_validation`](https://www.terraform.io/docs/providers/aws/r/acm_certificate_validation.html) resource
+
+It's important to note that the `aws_acm_certificate_validation` resource
+does not actually represent a real AWS resource -- it is an internal
+mechanism Terraform uses to correctly order the creation of resources
+dependent on a valid Terraform certificate. It is *not required* to
+actually validate an ACM certificate.
+
+However, the problem that the `aws_acm_certificate_validation` resource
+was designed to solve -- preventing Terraform from trying to use an
+invalid certificate on another resource, like an ALB -- still exists in
+GovCloud. The ACM certificate resource itself *cannot be used* until it
+has been validated. This means trying to create an ALB using an certificate
+that has not yet been validated will fail, and in GovCloud, this creates
+a timing issue, because we need to create the certificate to get the
+DNS validation information, but we have to create the DNS entry in the
+commercial organization before we can use it elsewhere in GovCloud.
+
+## The Solution: Step-By-Step Creation
+
+We can solve this by using a step-by-step creation method for our systems
+which require ACM certificates. We recommend *not* creating these
+certificates inside modules for your application, but instead providing
+the certificate as a parameter that resources in your module can use, as
+anything contingent on the successful creation of the certificate will fail
+on your first apply of the module if you do include it.
+
+To do this, here's some sample code for the creation of the ACM certificate
+in our GovCloud account:
+
+```hcl
+resource "aws_acm_certificate" "acm_myapp" {
+  domain_name       = "myapp.example.com"
+  validation_method = "DNS"
+
+  tags = {
+    Name        = "myapp.example.com"
+    Automation  = "Terraform"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "myapp_cert_validation" {
+  description = "Map of data for myapp cert validation"
+  value       = aws_acm_certificate.acm_myapp.domain_validation_options
+}
+```
+
+The output is necessary because this is what will provide us the information
+we need to create the validation DNS entry in our commercial AWS account. It
+will look like this:
+
+```terraform
+testing_cert_validation = [
+  {
+    "domain_name" = "myapp.example.com"
+    "resource_record_name" = "_42ef3fd691a332acfe219f37910eee14.myapp.example.com."
+    "resource_record_type" = "CNAME"
+    "resource_record_value" = "_31d89bcda5baf24c2518526a81f86617.tfmgdnztqk.acm-validations.aws."
+  },
+]
+```
+
+We can then take that output and create a DNS entry in our commercial DNS
+account with this code:
+
+```hcl
+resource "aws_route53_record" "myapp_acm_validation" {
+  zone_id = aws_route53_zone.myzone.zone_id
+  name    = "_42ef3fd691a332acfe219f37910eee14.myapp.example.com."
+  type    = "CNAME"
+  records = ["_31d89bcda5baf24c2518526a81f86617.tfmgdnztqk.acm-validations.aws."]
+  ttl     = 60
+}
+```
+
+Once this entry has been created, you should be able to use your certificate
+on other resources within a minute or two. If you want to confirm that the
+certificate has been validated, you can run these commands in the GovCloud
+account:
+
+```console
+$ aws acm list-certificates
+{
+    "CertificateSummaryList": [
+        {
+            "CertificateArn": "arn:aws:acm:us-west-2:000123456789:certificate/78dca028-1812-4fa5-9c84-b92fdeadbeef",
+            "DomainName": "myapp.example.com"
+        }
+    ]
+}
+
+$ aws acm describe-certificate --certificate-arn "arn:aws:acm:us-west-2:000123456789:certificate/78dca028-1812-4fa5-9c84-b92fdeadbeef"
+{
+    "Certificate": {
+        "CertificateArn": "arn:aws:acm:us-west-2:000123456789:certificate/78dca028-1812-4fa5-9c84-b92fdeadbeef",
+        "DomainName": "myapp.example.com",
+        "SubjectAlternativeNames": [
+            "myapp.example.com"
+        ],
+        "DomainValidationOptions": [
+            {
+                "DomainName": "myapp.example.com",
+                "ValidationDomain": "myapp.example.com",
+                "ValidationStatus": "SUCCESS",
+
+...
+```
+
+If your `ValidationStatus` is `SUCCESS`, your certificate should be ready to go.

--- a/infrasec/aws/govcloud/gov-orgs.md
+++ b/infrasec/aws/govcloud/gov-orgs.md
@@ -1,87 +1,11 @@
-# Working in GovCloud
+# [GovCloud](./README.md) / Setting Up a GovCloud Organization
 
-Many of our government clients will want to have at least their production
-infrastructure in [AWS GovCloud](https://aws.amazon.com/govcloud-us/), which
-is a set of AWS regions that are separate from commercial AWS regions, with
-a number of additional controls that allow them to conform to the higher
-security and compliance standards needed to meet federal guidelines like
-[FedRAMP](https://www.fedramp.gov/).
+Setting up organizations in GovCloud requires some additional steps due
+to the way GovCloud interacts (or rather, doesn't interact) with commercial
+AWS accounts. The instructions below will take you through the process of
+getting an organization and its accounts set up properly.
 
-## Notable Considerations With GovCloud
-
-* Every GovCloud account must be attached to a corresponding account in
-  commercial AWS (mostly for billing purposes). This has some impact on
-  how you build AWS Organizations in GovCloud (see below).
-* Commercial AWS and GovCloud resources cannot interact directly in any
-  way. This means that you cannot assume roles between the two or tie
-  a commercial resource to a GovCloud resource unless using some publicly
-  addressable method.
-* GovCloud accounts do not have a `root` user; they have an automatically
-  created IAM user named `Administrator` with full administrative
-  privileges. For most purposes, you can think of this as operating the
-  same way as the `root` user; however, it is still subject to restrictions
-  you place on all IAM users. This means setting password expiration to
-  a very short period (as is common in some of our commercial AWS
-  environments) can lock you out of the `Administrator` user; since we
-  can get console access via role assumption, we recommend setting the
-  password expiration on the GovCloud org-root account to six months and
-  instead treating this user as you would the `root` user in commercial
-  AWS (ie, do not use it for anything other than bootstrapping or
-  "break glass" cases).
-* GovCloud resources use a different AWS partition; this is the second
-  part of an ARN. So while an ARN for a commercial resource might look
-  like this:
-
-  ```text
-  arn:aws:iam::123456789000:user/testuser
-  ```
-
-  a GovCloud ARN will look like this:
-
-  ```text
-  arn:aws-us-gov:iam::123456789000:user/testuser
-  ```
-
-  This means that any Terraform modules will need to take this into
-  account; see the Terraform
-  [`aws_partition`](https://www.terraform.io/docs/providers/aws/d/partition.html)
-  data source for how to do this.
-* Many AWS services are not available in GovCloud; some are available
-  in one GovCloud region and not others. See the GovCloud
-  [Services in Scope](https://aws.amazon.com/compliance/services-in-scope/)
-  and the AWS [Region
-  Table](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/)
-  for more information.
-* Organization CloudTrails are not available in GovCloud. This means you
-  cannot add `cloudtrail.amazonaws.com` as a service principal in your
-  organization Terraform code.
-* Your first GovCloud account will have a randomly-named S3 bucket called
-  something like "cloudtrail-123456789abcedf", and all additional GovCloud
-  accounts you create via the method described in this document will have
-  a randomly-named CloudTrail and matching S3 bucket automatically created.
-  We recommend replacing these resources with your own CloudTrail pointing
-  to the AWS service logs bucket you create in the account.
-* It is not possible to enable CloudWatch Container Insights for an ECS
-  cluster. Therefore, in `aws_ecs_cluster` Terraform resources, you cannot
-  include a `setting` configuration block with `containerInsights`.
-* For Amazon RDS, GovCloud does not support `backup` or `read replica`
-  events. Therefore event notifications and subscriptions are impossible
-  for those events.
-* As of 04/20, the most up-to-date CA cert identifier for RDS instances
-  that is viable in GovCloud is `rds-ca-2017` rather than `rds-ca-2019`.
-* Because GovCloud doesn't have a root account in the traditional sense
-  (it's tied to a commerical root account), you cannot set
-  `check_root_account_mfa_enabled` to true in Truss' [AWS
-  Config](https://registry.terraform.io/modules/trussworks/config/aws)
-  module.
-* While Route53 is available in GovCloud, it is *only* available for
-  private DNS, which limits its utility somewhat. You will need to create
-  public DNS entries for your GovCloud environments in your commercial
-  AWS environment.
-
-## Setting Up a GovCloud Organization
-
-### Create Your GovCloud Organization Master Account
+## Create Your GovCloud Organization Master Account
 
 To set up a new GovCloud AWS Organization, you must log in as root to the
 master account of your commercial AWS Organization. Then go to the "My
@@ -102,7 +26,7 @@ add `cloudtrail.amazonaws.com` as a service access principal in your
 organization definition because organization CloudTrails are not available
 in GovCloud.
 
-### Creating Additional GovCloud Accounts
+## Creating Additional GovCloud Accounts
 
 To add more accounts to your GovCloud organization, you *cannot* simply
 use the Terraform `aws_organizations_account` resource. Using credentials
@@ -184,7 +108,7 @@ output=json
 
 Once you've added IAM users in the `-id` account later on, you can change this profile to not use the OrganizationAccountAccessRole anymore; as with commercial AWS accounts, you should use resources from the organization master account as sparingly as possible.
 
-### Adding Your New GovCloud Account to Your GovCloud Organization
+## Adding Your New GovCloud Account to Your GovCloud Organization
 
 To add the account you just created to your GovCloud organization, run
 this command with your appropriate credentials from the GovCloud
@@ -234,7 +158,7 @@ Then run this command:
 $ terraform import aws_organizations_account.spacecats_govcloud_id 000987654321
 ```
 
-### Handling GovCloud Dummy Accounts in AWS Commercial
+## Handling GovCloud Dummy Accounts in AWS Commercial
 
 As stated above, when you use the AWS CLI to create your new GovCloud
 accounts, it will also create a dummy account with the same account name


### PR DESCRIPTION
This does a little reorganization of the GovCloud material to split it up (the single page was getting a little long) and adds a guide to how to create ACM certificates in GovCloud.