### PR TITLE
Mdawn minor readme updates

### DIFF
--- a/infrasec/README.md
+++ b/infrasec/README.md
@@ -57,4 +57,4 @@ response](../incident-response/README.md), and a number of other fields.
 
 - [Alert Providers](./alert-providers.md)
 - [Project Teardown Guide](./teardown.md)
-- [SSL Certificates](./certs/README.md)
+- [SSL Certificates](./certs.md)

--- a/infrasec/tf/terratest.md
+++ b/infrasec/tf/terratest.md
@@ -162,15 +162,11 @@ if [[ -n ${CIRCLECI-} ]]; then
 fi
 ```
 
-Save this script with a filename like `make-test` and make it executable using `chmod +x make-test`. Now we'll add a call to the executable in our Makefile (remembering to clean out the bin!) like so:
+Save this script with a filename like `make-test` and make it executable using `chmod +x make-test`. Now we'll add a call to the executable in our Makefile like so:
 
 ```
 .PHONY: test
 test: bin/make-test
-
-.PHONY: clean
-clean:
-  rm -rf bin
 ```
 
 Finally we update our `.circleci/config` by adding two steps - one to `go get` the package and another to access our shiny new executable:


### PR DESCRIPTION
Changes proposed:

- updates link to `certs.md`
- removes inaccuracy regarding make calls (the bin need not be cleaned)