### PR TITLE
Mdawn migrate to new image 174581619

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,12 @@
 version: 2
+
+references:
+  circleci: &circleci trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:a18ba9987556eec2e48354848a3c9fb4d5b69ac8
+      - image: *circleci
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
@@ -8,7 +8,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.1
+    rev: v0.23.2
     hooks:
       - id: markdownlint
 


### PR DESCRIPTION
# [Migrate Images](https://www.pivotaltracker.com/story/show/174581619)

Changes proposed in this pull request:

- replace any instance of `circleci-docker-primary` with `circleci` (also moves out to ref var)
- updates pre-commit yaml