### PR TITLE
Update pre-commit-hooks to 1.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: markdownlint
 
   - repo: git://github.com/trussworks/pre-commit-hooks
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: markdown-toc
       - id: circleci-validate


### PR DESCRIPTION
This latest release fixes the markdown-toc issues people have been
seeing.