### PR TITLE
Document CircleCI Diff Tool

### DIFF
--- a/developing/cicd/README.md
+++ b/developing/cicd/README.md
@@ -10,6 +10,7 @@ according to Truss best practices to deliver software to customers.
 * [Standard Delivery Pipeline](delivery-pipeline.md)
 * [CircleCI Config Patterns](circleci-patterns.md)
 * [CircleCI Orbs](circleci-orbs.md)
+* [CircleCI Utilities](circleci-utilities.md)
 * [Dependabot](dependabot.md)
 
 ## Resources

--- a/developing/cicd/circleci-utilities.md
+++ b/developing/cicd/circleci-utilities.md
@@ -11,7 +11,7 @@ The example below leverages a GET request to get the details of a given PR, spec
 <details>
   <summary>GET Pull Request changed files</summary>
 
-  ### Useful resources:
+  References:
   [Only build Pull Requests](https://circleci.com/docs/2.0/oss/#only-build-pull-requests)
   [Built-in environment variables](https://circleci.com/docs/2.0/env-vars/?section=pipelines#built-in-environment-variables)
   [Get PR number from CircleCI pull request build](https://support.circleci.com/hc/en-us/articles/360047521451-Why-is-CIRCLE-PR-NUMBER-empty-)
@@ -39,4 +39,5 @@ The example below leverages a GET request to get the details of a given PR, spec
             environment:
               TERM: xterm-256color
   ```
+  
 </details>

--- a/developing/cicd/circleci-utilities.md
+++ b/developing/cicd/circleci-utilities.md
@@ -20,11 +20,11 @@ The example below leverages a GET request to get the details of a given PR, spec
 
   ```yaml
   jobs:
-    get-pull-request-changes: 
+    get-pull-request-changes:
       executor: main
       steps:
         - checkout
-        - run: 
+        - run:
             name: "git PR diff"
             command: |
               pr_number=${CIRCLE_PULL_REQUEST##*/}

--- a/developing/cicd/circleci-utilities.md
+++ b/developing/cicd/circleci-utilities.md
@@ -39,5 +39,5 @@ The example below leverages a GET request to get the details of a given PR, spec
             environment:
               TERM: xterm-256color
   ```
-  
+
 </details>

--- a/developing/cicd/circleci-utilities.md
+++ b/developing/cicd/circleci-utilities.md
@@ -1,0 +1,42 @@
+# [CI/CD](README.md) / CircleCI Utilities
+
+There are common tasks that may be useful to build into CircleCI commands and jobs to inform more complex build pipeline logic. Since CircleCI does not support orbs designed to return values which can be passed into other commands as parameters, it can be difficult to create reusable orbs for these purposes.
+
+## Make Github API Requests
+
+CircleCI pipelines provide some information about the VCS, but there are scenarios where more information may be required. One way to access more information is to use the [Github API](https://docs.github.com/en/rest/reference/) within a job or command.
+
+The example below leverages a GET request to get the details of a given PR, specifically extracting the PR's base branch commit SHA. This base SHA combined with the CircleCI-provided pipeline SHA is used to get a list of which files were changed. The output could be used within other steps of a more complex job (e.g. determining what parts of a pipeline should run based on what files were changed)
+
+<details>
+  <summary>GET Pull Request changed files</summary>
+
+  ### Useful resources:
+  [Only build Pull Requests](https://circleci.com/docs/2.0/oss/#only-build-pull-requests)
+  [Built-in environment variables](https://circleci.com/docs/2.0/env-vars/?section=pipelines#built-in-environment-variables)
+  [Get PR number from CircleCI pull request build](https://support.circleci.com/hc/en-us/articles/360047521451-Why-is-CIRCLE-PR-NUMBER-empty-)
+  [Github API - GET Pull Request API](https://docs.github.com/en/rest/reference/pulls#get-a-pull-request)
+  [git diff](https://git-scm.com/docs/git-diff)
+
+  ```yaml
+  jobs:
+    get-pull-request-changes: 
+      executor: main
+      steps:
+        - checkout
+        - run: 
+            name: "git PR diff"
+            command: |
+              pr_number=${CIRCLE_PULL_REQUEST##*/}
+              base_sha=$( \
+                curl \
+                -s \
+                -H "Accept: application/vnd.github.v3+json" \
+                https://api.github.com/repos/"${CIRCLE_PROJECT_USERNAME}"/"${CIRCLE_PROJECT_REPONAME}"/pulls/"${pr_number}" \
+                | jq -r '.base.sha'
+              )
+              git diff "$base_sha" "$CIRCLE_SHA1" --name-only
+            environment:
+              TERM: xterm-256color
+  ```
+</details>


### PR DESCRIPTION
Document an approach to adding logic to CircleCI pipelines to determine the changes from a given PR. The example use case is for use within a monorepo where certain file changes should not require build + test of all the code. This would allow pipelines to intelligently select what to do based on what changed.

For additional context, please see:
 - The raised issue: https://github.com/trussworks/appeng/issues/44
 - A test project PR where I was learning CircleCI and testing this job: https://github.com/brandonlenz/circle-ci-test-repo/pull/2

Personally, I get the feeling that this would be useful as a reusable utility in the form of an Orb, but as far as I can tell CircleCI does not support returning values from an Orbs job to then be used as input parameters for other jobs or commands. The diff can be stored as a BASH_ENV variable and passed to different steps, or maybe shared between workspaces as far as I understand, however.

I was also a bit unsure of where to put this information. I'm good to move it if someone is aware of a better location. Creating anything "utilities" or "utils" related is normally a code smell, so I'm not feeling confident, but didn't know what else to call this.