### PR TITLE
Add mention of graphql-schema-linter to docs.

### DIFF
--- a/web/api/GraphQL-Design-Guide.md
+++ b/web/api/GraphQL-Design-Guide.md
@@ -88,3 +88,7 @@ untyped `errors` field. This makes the most sense for errors that are
 specific to the operation being made that you want the client to
 handle gracefully. It also encourages you to include errors as part of
 your domain modeling, which is a good thing.
+
+### Tooling
+
+Using a schema linter (such as [graphql-schema-linter](https://github.com/cjoudrey/graphql-schema-linter)) and running it as part of your pre-commit checks is recommended. Some of the defaults of such linters may be optimized for large public APIs and should be adjusted to best suit your project.


### PR DESCRIPTION
This PR adds mention of using a schema linter to the GraphQL docs.