### PR TITLE
Draft: Creating AppEng ADR Process

### DIFF
--- a/practices/appeng/README.md
+++ b/practices/appeng/README.md
@@ -7,7 +7,18 @@ including and mostly dealing with web development.
 This section includes resources
 the practice uses to organize around.
 
-* [Team Charter](team-charter.md) How we set direction as a practice
+## Organizational Resources
+
+Tools we use to organize our people and projects
+
+* [Team Charter](team-charter.md)--what principles drive our engineering culture
 * [🔒AppEng Directory](https://docs.google.com/spreadsheets/d/1wzlDUjMsHv8mfam7XaCVjw9F5UTrE7U9pJEQa5dEiAA/edit#gid=0) Projects and members of the practice and their specialties
 * [🔒Rose Chart Core Skill Guide](https://docs.google.com/document/d/1pj3y0lJYMWIZCkmd8I64GDOESwgOwh7TOGRLVAEiw6g) Description of how to use the Rose Chart framework for career growth
 * [🔒Practice Rose Charts](https://docs.google.com/spreadsheets/d/1eVo3bo6VZafMpLqI6l0lr8VknYbqYvEY3bUGl0vfWMg/edit#gid=0) Filled out Rose Charts
+
+## Technical Direction
+
+Tools and process for how we set technical direction and make decisions
+
+* [Decision Process](decision-process.txt)--how to commit and revise practice level decisions
+* [Records](./adrs)--the outcomes we've come to

--- a/practices/appeng/decision-process.md
+++ b/practices/appeng/decision-process.md
@@ -28,12 +28,12 @@ At it's core decision making process is as follows:
 The timeline may look as follows:
 
 | Time  | Action | Owner |
-| --- || --- | --- |
+| --- | --- | --- |
 | Start of quarter | Write ADRs  | All  |
 | Two weeks before last Leads meeting of quarter | Announce new ADRs   | ADR authors |
-| Two weeks before last Leads meeting of quarter | Review ADRs   | all |
+| Two weeks before last Leads meeting of quarter | Review ADRs   | All |
 | Last Leads meeting of quarter | Discuss ADRs and seek decision  | Leads, Domain Group Leaders, Authors  |
-| One month after meeting | Documentation is written for new decisions | Authors  |
+| One month after meeting | Write documentation for new decisions | Authors  |
 
 ## Writing an ADR
 

--- a/practices/appeng/decision-process.md
+++ b/practices/appeng/decision-process.md
@@ -57,13 +57,13 @@ we've established domain groups
 that have responsibility over a certain part of the stack.
 Currently these are broken up into:
 
-* _Frontend_ - For decisions around browser technology,
+* **Frontend** - For decisions around browser technology,
   frontend frameworks,
   and client side data modeling.
-* _Server_ - For decisions that deal with database modeling,
+* **Server** - For decisions that deal with database modeling,
   processing,
   and general API building.
-* _Other_(better name please) - For decisions that fall outside of the other two groups
+* **Other**(better name please) - For decisions that fall outside of the other two groups
   or heavily incorporate both.
   This will likely be broken out into other groups
   as we discover what topics come up.

--- a/practices/appeng/decision-process.md
+++ b/practices/appeng/decision-process.md
@@ -22,18 +22,18 @@ At it's core decision making process is as follows:
 3. Workshop the ADR with a [Domain Group](#domain-groups)
   and create a final draft.
 4. Propose it in Slack for all of AppEng for review.
-5. Represent it at the [quarterly decision meeting](#quarterly-meeting).
+5. (Optional) Hold a [meeting](#review-meeting) for review.
 6. Commit the [ADR](./adrs) and create [implementation documentation](#output).
 
 The timeline may look as follows:
 
-| Time  | Action | Owner |
-| --- | --- | --- |
-| Start of quarter | Write ADRs  | All  |
-| Before two weeks before last Leads meeting of quarter | Announce new ADRs   | ADR authors |
-| Within two weeks before last Leads meeting of quarter | Review ADRs   | All |
-| Last Leads meeting of quarter | Discuss ADRs and seek decision  | Leads, Domain Group Leaders, Authors  |
-| One month after meeting | Write documentation for new decisions | Authors  |
+|Action | Owner |
+| --- | --- |
+| Write ADRs continuously | All  |
+| Announce new ADR to #appeng   | ADR authors |
+| Review ADRs   | All |
+| At least two weeks after announcement, have review meeting  | Domain Group Leader, Authors, Reviewers  |
+| Write documentation for new decisions | Authors  |
 
 ## Writing an ADR
 
@@ -80,7 +80,9 @@ Currently these are broken up into:
 
 While guilds are established as topical and cross practice,
 domain groups that overlap with guilds may choose to use their time
-to workshop or prompt new ADRs.
+to prompt new ADRs,
+workshop,
+or review them.
 These are not explicitly 1:1 in overlap
 and leadership structures are not synonymous.
 
@@ -98,33 +100,28 @@ and have established specialization within their group's domain.
 They should also have a year experience at Truss.
 
 Group leaders are also responsible for connecting practice members
-with domain experts that can help them craft decisions best.
+with domain experts that can help them craft decisions best
+and reviewers to provide feedback.
 Their motivation should be to create a collaborative experience
 and effective group output.
 
 The rough expectation for time from a group leader is one hour per week.
-They are responsible for representing their domain
-in quarterly AppEng checkins.
 
-## Quarterly Meetings
+## Review Meetings
 
-Quarterly meetings happen over the last AppEng Leads meeting of a quarter.
-Team leads,
-domain group leaders,
-and any ADR representatives are required to attend.
-Proposed ADRs are sourced two weeks prior to the meeting,
-and are required to have at least that much time
-for asyncronous feedback from the practice.
-The agenda will be set by practice leadership
-in collaboration with domain group leaders.
+If a decision is contested
+or requires syncronous clarification,
+a review meeting should happen.
+The author of the ADR
+is responsible for scheduling the meeting
+and announcing it to #appeng for attendance.
+The author,
+domain group leader,
+and reviewers should be in attendance.
 
-ADR authors will summarize their decision
-followed by a period for discussion.
-This is *not* a time to read,
-collect,
-or incorporate new feedback.
-Meeting time should only be used to provide brief dissent
-and clarification.
+Review meetings should happen at earliest two weeks after an ADR is announced.
+This isn't to say folks can't collaborate earlier,
+but having asyncronous time to review and incorporate feedback is helpful.
 
 If a clear consensus can be found during the meeting,
 the domain group leader for the decision may move it forward.
@@ -146,7 +143,7 @@ there are three follow ups required:
 3. Write implementation documentation in this playbook.
 
 ADRs authors are responsible for the corresponding documentation.
-Practice leadership will check in one month after the quarterly meeting
+Practice leadership will check in on recent ADRs
 to ensure documentation has been written to reflect the decision.
 
 ## Project Implementation

--- a/practices/appeng/decision-process.md
+++ b/practices/appeng/decision-process.md
@@ -30,8 +30,8 @@ The timeline may look as follows:
 | Time  | Action | Owner |
 | --- | --- | --- |
 | Start of quarter | Write ADRs  | All  |
-| Two weeks before last Leads meeting of quarter | Announce new ADRs   | ADR authors |
-| Two weeks before last Leads meeting of quarter | Review ADRs   | All |
+| Before two weeks before last Leads meeting of quarter | Announce new ADRs   | ADR authors |
+| Within two weeks before last Leads meeting of quarter | Review ADRs   | All |
 | Last Leads meeting of quarter | Discuss ADRs and seek decision  | Leads, Domain Group Leaders, Authors  |
 | One month after meeting | Write documentation for new decisions | Authors  |
 

--- a/practices/appeng/decision-process.md
+++ b/practices/appeng/decision-process.md
@@ -57,13 +57,13 @@ we've established domain groups
 that have responsibility over a certain part of the stack.
 Currently these are broken up into:
 
-* *Frontend* - For decisions around browser technology,
+* _Frontend_ - For decisions around browser technology,
   frontend frameworks,
   and client side data modeling.
-* *Server* - For decisions that deal with database modeling,
+* _Server_ - For decisions that deal with database modeling,
   processing,
   and general API building.
-* *Other*(better name please) - For decisions that fall outside of the other two groups
+* _Other_(better name please) - For decisions that fall outside of the other two groups
   or heavily incorporate both.
   This will likely be broken out into other groups
   as we discover what topics come up.

--- a/practices/appeng/decision-process.md
+++ b/practices/appeng/decision-process.md
@@ -25,16 +25,6 @@ At it's core decision making process is as follows:
 5. (Optional) Hold a [meeting](#review-meeting) for review.
 6. Commit the [ADR](./adrs) and create [implementation documentation](#output).
 
-The timeline may look as follows:
-
-|Action | Owner |
-| --- | --- |
-| Write ADRs continuously | All  |
-| Announce new ADR to #appeng   | ADR authors |
-| Review ADRs   | All |
-| At least two weeks after announcement, have review meeting  | Domain Group Leader, Authors, Reviewers  |
-| Write documentation for new decisions | Authors  |
-
 ## Writing an ADR
 
 ADRs are a lightweight format that allows us

--- a/practices/appeng/decision-process.md
+++ b/practices/appeng/decision-process.md
@@ -63,7 +63,7 @@ Currently these are broken up into:
 * **Server** - For decisions that deal with database modeling,
   processing,
   and general API building.
-* **Other**(better name please) - For decisions that fall outside of the other two groups
+* **General**(better name please) - For decisions that fall outside of the other two groups
   or heavily incorporate both.
   This will likely be broken out into other groups
   as we discover what topics come up.

--- a/practices/appeng/decision-process.md
+++ b/practices/appeng/decision-process.md
@@ -22,8 +22,8 @@ At it's core decision making process is as follows:
 3. Workshop the ADR with a [Domain Group](#domain-groups)
   and create a final draft.
 4. Propose it in Slack for all of AppEng for review.
-6. Represent it at the [quarterly decision meeting](#quarterly-meeting).
-7. Commit the [ADR](./adrs) and create [implementation documentation](#output).
+5. Represent it at the [quarterly decision meeting](#quarterly-meeting).
+6. Commit the [ADR](./adrs) and create [implementation documentation](#output).
 
 ## Writing an ADR
 
@@ -56,6 +56,7 @@ In order to organize members across projects,
 we've established domain groups
 that have responsibility over a certain part of the stack.
 Currently these are broken up into:
+
 * Frontend - For decisions around browser technology,
   frontend frameworks,
   and client side data modeling.

--- a/practices/appeng/decision-process.md
+++ b/practices/appeng/decision-process.md
@@ -57,13 +57,13 @@ we've established domain groups
 that have responsibility over a certain part of the stack.
 Currently these are broken up into:
 
-* Frontend - For decisions around browser technology,
+* *Frontend* - For decisions around browser technology,
   frontend frameworks,
   and client side data modeling.
-* Server - For decisions that deal with database modeling,
+* *Server* - For decisions that deal with database modeling,
   processing,
   and general API building.
-* Other - For decisions that fall outside of the other two groups
+* *Other*(better name please) - For decisions that fall outside of the other two groups
   or heavily incorporate both.
   This will likely be broken out into other groups
   as we discover what topics come up.
@@ -150,6 +150,7 @@ and applications are similar to a past pattern,
 projects should seek to utilize known resources first.
 Practice ADR repositories should be consulted
 prior to writing a new ADR.
+
 In the end,
 it is the Eng Lead's responsibility
 to decide when a decision is applicable.

--- a/practices/appeng/decision-process.md
+++ b/practices/appeng/decision-process.md
@@ -25,6 +25,16 @@ At it's core decision making process is as follows:
 5. Represent it at the [quarterly decision meeting](#quarterly-meeting).
 6. Commit the [ADR](./adrs) and create [implementation documentation](#output).
 
+The timeline may look as follows:
+
+| Time  | Action | Owner |
+| --- || --- | --- |
+| Start of quarter | Write ADRs  | All  |
+| Two weeks before last Leads meeting of quarter | Announce new ADRs   | ADR authors |
+| Two weeks before last Leads meeting of quarter | Review ADRs   | all |
+| Last Leads meeting of quarter | Discuss ADRs and seek decision  | Leads, Domain Group Leaders, Authors  |
+| One month after meeting | Documentation is written for new decisions | Authors  |
+
 ## Writing an ADR
 
 ADRs are a lightweight format that allows us
@@ -98,7 +108,7 @@ in quarterly AppEng checkins.
 
 ## Quarterly Meetings
 
-Quarterly meetings happen over the first AppEng Leads meeting of a quarter.
+Quarterly meetings happen over the last AppEng Leads meeting of a quarter.
 Team leads,
 domain group leaders,
 and any ADR representatives are required to attend.

--- a/practices/appeng/decision-process.txt
+++ b/practices/appeng/decision-process.txt
@@ -1,0 +1,158 @@
+# AppEng Decision Process
+
+Application Engineers are staffed sparsely across projects at Truss.
+This means engineers are often working on unrelated
+products, code bases and technologies.
+Because of this,
+we've created some intentional structure
+to facilitate decision making,
+share what has/hasn't gone well,
+and incorporate common patterns into our main playbook.
+Due to the variance in projects,
+we don't expect a one-size-fits-all mentality to decision making.
+However, we do hope to account for some prominent cases
+and highlight when certain applications make sense.
+
+## How to Make a Decision
+
+At it's core decision making process is as follows:
+
+1. Identify a decision made on a project that is applicable to the whole practice.
+2. Write an Architectural Decision Record (ADR) justifying it.
+3. Workshop the ADR with a [Domain Group](#domain-groups)
+  and create a final draft.
+4. Propose it in Slack for all of AppEng for review.
+6. Represent it at the [quarterly decision meeting](#quarterly-meeting).
+7. Commit the [ADR](./adrs) and create [implementation documentation](#output).
+
+## Writing an ADR
+
+ADRs are a lightweight format that allows us
+to identify use cases and solutions for problems we face in our engineering.
+In AppEng,
+we're incorporating ADRs into our practice
+because they're the format we commonly communicate with,
+advocate for,
+and have had success with on projects.
+
+On the practice level,
+decision records may look different than those on projects.
+While the end result may be similar,
+the justification may require further elaboration
+around why this decision may benefit as a whole.
+More specifically,
+what common use case or pattern may this solve for.
+(TODO: add guide/clarity on how to do this
+along with initial examples that demonstrate it)
+
+More information around process
+and structure for ADRs can be found in the
+[Architecural Decision Records](../../documentation/adr.md)
+section of the playbook.
+
+## Domain Groups
+
+In order to organize members across projects,
+we've established domain groups
+that have responsibility over a certain part of the stack.
+Currently these are broken up into:
+* Frontend - For decisions around browser technology,
+  frontend frameworks,
+  and client side data modeling.
+* Server - For decisions that deal with database modeling,
+  processing,
+  and general API building.
+* Other - For decisions that fall outside of the other two groups
+  or heavily incorporate both.
+  This will likely be broken out into other groups
+  as we discover what topics come up.
+
+While guilds are established as topical and cross practice,
+domain groups that overlap with guilds may choose to use their time
+to workshop or prompt new ADRs.
+These are not explicitly 1:1 in overlap
+and leadership structures are not synonymous.
+
+### Group Leaders
+
+Groups leaders are accountable for moving forward their group's decisions.
+They should seek to delegate and create alignment among the group,
+however end decision making power lies with them.
+One leader will be assigned per group,
+and serve a six month term.
+Practice leadership will call for nominees from the practice
+and pick leaders in between those terms.
+Group leaders should be at a minimum level 3
+and have established specialization within their group's domain.
+They should also have a year experience at Truss.
+
+Group leaders are also responsible for connecting practice members
+with domain experts that can help them craft decisions best.
+Their motivation should be to create a collaborative experience
+and effective group output.
+
+The rough expectation for time from a group leader is one hour per week.
+They are responsible for representing their domain
+in quarterly AppEng checkins.
+
+## Quarterly Meetings
+
+Quarterly meetings happen over the first AppEng Leads meeting of a quarter.
+Team leads,
+domain group leaders,
+and any ADR representatives are required to attend.
+Proposed ADRs are sourced two weeks prior to the meeting,
+and are required to have at least that much time
+for asyncronous feedback from the practice.
+The agenda will be set by practice leadership
+in collaboration with domain group leaders.
+
+ADR authors will summarize their decision
+followed by a period for discussion.
+This is *not* a time to read,
+collect,
+or incorporate new feedback.
+Meeting time should only be used to provide brief dissent
+and clarification.
+
+If a clear consensus can be found during the meeting,
+the domain group leader for the decision may move it forward.
+Otherwise,
+the domain group leader is responsible
+for following up with the ADR author
+and establishing deciders/decision making criteria.
+The group leader may delegate decision power,
+but is accountable for a decision no later than
+one week after the meeting.
+
+## Output
+
+Once a decision is made,
+there are three follow ups required:
+
+1. Commit the ADR.
+2. Announce the decision in #appeng.
+3. Write implementation documentation in this playbook.
+
+ADRs authors are responsible for the corresponding documentation.
+Practice leadership will check in one month after the quarterly meeting
+to ensure documentation has been written to reflect the decision.
+
+## Project Implementation
+
+We recognize that projects vary at Truss,
+and it would be impossible to verbatim follow these decisions.
+Some projects will use tools based on client needs,
+or some may work in completely different domains.
+When Truss is responsible for the technology decisions
+and applications are similar to a past pattern,
+projects should seek to utilize known resources first.
+Practice ADR repositories should be consulted
+prior to writing a new ADR.
+In the end,
+it is the Eng Lead's responsibility
+to decide when a decision is applicable.
+If a relevant ADR is ignored,
+the Eng Lead (or a delegate) should write justification within their project's new ADR.
+If the decision is succesful/overturns an existing one,
+a new ADR should be proposed to the practice using the above process.


### PR DESCRIPTION
@ntwyman and @ahobson here are some initial thoughts at what structure could look like for bringing in an ADR process to the practice. My assumption is we would do a "dry run" with some clear decisions that we've neglected to standardize in the past for the first quarter and go from there. This would give us the opportunity to experiment.

Feedback needed is mostly around:
* General structure. Is it too lightweight or too structured?
* Time commitments. Will this as actually get done given our time constraints?
* Group structure. Does this breakdown make sense?

Open to all feedback though and can go over in a meeting together.