### PR TITLE
Update Nix docs about Nix Channels

### DIFF
--- a/developing/nix/HOWTO.md
+++ b/developing/nix/HOWTO.md
@@ -97,11 +97,12 @@ This HOWTO assumes you already have nix installed.
    fi
    ```
 
-1. Use
-   [nix-package-search](https://ahobson.github.io/nix-package-search/#/)
-   to find your package versions and add them to your
-   `nix/default.nix` in the `paths` section. Your new `default.nix`
-   might look something like (with NAME replaced with your project)
+1. Use [nix-package-search][ahobson-nix-package-search] to find your package
+   versions and add them to your `nix/default.nix` in the `paths` section. Your
+   new `default.nix` might look something like (with NAME replaced with your
+   project)
+
+   [ahobson-nix-package-search]: https://ahobson.github.io/nix-package-search/#/
 
    ```
    let

--- a/developing/nix/HOWTO.md
+++ b/developing/nix/HOWTO.md
@@ -123,7 +123,7 @@ This HOWTO assumes you already have nix installed.
    }
    ```
    <details>
-   <summary>📝 <h4 style="display:inline;">Click here to open a note about the <code>ref="refs/head/nixpkgs-unstable";</code> line from the step above</h4></summary>
+   <summary><h4>📝 Click here to open a note about the <code>ref="refs/head/nixpkgs-unstable";</code> line from the step above</h4></summary>
 
    In the step above, you may need to modify the `ref="{BRANCH_NAME}";` line
    with a different branch for the [NixOS/nixpkgs repository][gh-nixpkgs] if you

--- a/developing/nix/HOWTO.md
+++ b/developing/nix/HOWTO.md
@@ -4,6 +4,30 @@ This HOWTO assumes you already have nix installed.
 
 ## Setting up a new project
 
+<details>
+<summary><b>📝 Click here to open a note about Nix Channels i.e. <code>ref="refs/head/nixpkgs-unstable";</code>.<br>You will want to read this if you've run into Git-related errors.</b></summary>
+
+In the step above, you may need to modify the `ref="{BRANCH_NAME}";` line
+with a different branch for the [NixOS/nixpkgs repository][gh-nixpkgs] if you
+encounter any Git-related errors.
+
+Trussels using Nix for package management have run into issues related to
+commits not being found on that specific `nixpkgs-unstable` branch. The
+[nix-package-search][ahobson-nix-package-search] will report the `ref` to be
+`nixpkgs-unstable` but the actual commit may not exist on that branch due to
+integration errors within the [NixOS/nixpkgs repository][gh-nixpkgs] that
+eventually may correct itself.
+
+To read up on Nix Channels, see [their documentation][docs-nix-channels].
+While the branch `nixpkgs-unstable` specifically lags behind `master` to
+thoroughly test things, some of our Truss projects are required to be
+up-to-date. This means that we may need to update some `ref="";` sections of
+the Import statement to point to `master` to upgrade or downgrade a single
+package in order to maintain our obligations to keep our dependencies
+up-to-date.
+
+</details>
+
 1. Create a `nix` directory
 
    mkdir -p `./nix`
@@ -102,8 +126,6 @@ This HOWTO assumes you already have nix installed.
    new `default.nix` might look something like (with NAME replaced with your
    project)
 
-   [ahobson-nix-package-search]: https://ahobson.github.io/nix-package-search/#/
-
    ```
    let
      pkgs = import <nixpkgs> {};
@@ -122,32 +144,6 @@ This HOWTO assumes you already have nix installed.
      ];
    }
    ```
-   <details>
-   <summary><h4>📝 Click here to open a note about the <code>ref="refs/head/nixpkgs-unstable";</code> line from the step above</h4></summary>
-
-   In the step above, you may need to modify the `ref="{BRANCH_NAME}";` line
-   with a different branch for the [NixOS/nixpkgs repository][gh-nixpkgs] if you
-   encounter any Git-related errors.
-
-   Trussels using Nix for package management have run into issues related to
-   commits not being found on that specific `nixpkgs-unstable` branch. The
-   [nix-package-search][ahobson-nix-package-search] will report the `ref` to be
-   `nixpkgs-unstable` but the actual commit may not exist on that branch due to
-   integration errors within the [NixOS/nixpkgs repository][gh-nixpkgs] that
-   eventually may correct itself.
-
-   To read up on Nix Channels, see [their documentation][docs-nix-channels].
-   While the branch `nixpkgs-unstable` specifically lags behind `master` to
-   thoroughly test things, some of our Truss projects are required to be
-   up-to-date. This means that we may need to update some `ref="";` sections of
-   the Import statement to point to `master` to upgrade or downgrade a single
-   package in order to maintain our obligations to keep our dependencies
-   up-to-date.
-
-   [gh-nixpkgs]: https://github.com/NixOS/nixpkgs
-   [docs-nix-channels]: https://nixos.wiki/wiki/Nix_channels
-
-   </details>
 
 1. Use `direnv allow` to set up the new environment variables
 
@@ -160,3 +156,7 @@ This HOWTO assumes you already have nix installed.
 1. You can then update `nix/default.nix` when you need to add/update
    packages and then `direnv` will let you know your packages are out
    of date and you need to run `./nix/update.sh`
+
+[ahobson-nix-package-search]: https://ahobson.github.io/nix-package-search/#/
+[docs-nix-channels]: https://nixos.wiki/wiki/Nix_channels
+[gh-nixpkgs]: https://github.com/NixOS/nixpkgs

--- a/developing/nix/HOWTO.md
+++ b/developing/nix/HOWTO.md
@@ -122,6 +122,32 @@ This HOWTO assumes you already have nix installed.
      ];
    }
    ```
+   <details>
+   <summary>📝 <h4 style="display:inline;">Click here to open a note about the <code>ref="refs/head/nixpkgs-unstable";</code> line from the step above</h4></summary>
+
+   In the step above, you may need to modify the `ref="{BRANCH_NAME}";` line
+   with a different branch for the [NixOS/nixpkgs repository][gh-nixpkgs] if you
+   encounter any Git-related errors.
+
+   Trussels using Nix for package management have run into issues related to
+   commits not being found on that specific `nixpkgs-unstable` branch. The
+   [nix-package-search][ahobson-nix-package-search] will report the `ref` to be
+   `nixpkgs-unstable` but the actual commit may not exist on that branch due to
+   integration errors within the [NixOS/nixpkgs repository][gh-nixpkgs] that
+   eventually may correct itself.
+
+   To read up on Nix Channels, see [their documentation][docs-nix-channels].
+   While the branch `nixpkgs-unstable` specifically lags behind `master` to
+   thoroughly test things, some of our Truss projects are required to be
+   up-to-date. This means that we may need to update some `ref="";` sections of
+   the Import statement to point to `master` to upgrade or downgrade a single
+   package in order to maintain our obligations to keep our dependencies
+   up-to-date.
+
+   [gh-nixpkgs]: https://github.com/NixOS/nixpkgs
+   [docs-nix-channels]: https://nixos.wiki/wiki/Nix_channels
+
+   </details>
 
 1. Use `direnv allow` to set up the new environment variables
 

--- a/developing/nix/HOWTO.md
+++ b/developing/nix/HOWTO.md
@@ -2,13 +2,17 @@
 
 This HOWTO assumes you already have nix installed.
 
-## Setting up a new project
+## Nix Channels
 
-<details>
-<summary><b>📝 Click here to open a note about Nix Channels i.e. <code>ref="refs/head/nixpkgs-unstable";</code>.<br>You will want to read this if you've run into Git-related errors.</b></summary>
+We currently recommend using the [Nix Unstable channel][hydra-nixpkgs-unstable]
+by default as it contains the latest tested updates on a rolling basis. This
+means that the branch for the [NixOS/nixpkgs repository][gh-nixpkgs] that is
+used is the `nixpkg-unstable` branch.
+
+### Troubleshooting Git-related errors
 
 In the step above, you may need to modify the `ref="{BRANCH_NAME}";` line
-with a different branch for the [NixOS/nixpkgs repository][gh-nixpkgs] if you
+with the `master` branch for the [NixOS/nixpkgs repository][gh-nixpkgs] if you
 encounter any Git-related errors.
 
 Trussels using Nix for package management have run into issues related to
@@ -26,7 +30,7 @@ the Import statement to point to `master` to upgrade or downgrade a single
 package in order to maintain our obligations to keep our dependencies
 up-to-date.
 
-</details>
+## Setting up a new project
 
 1. Create a `nix` directory
 
@@ -160,3 +164,4 @@ up-to-date.
 [ahobson-nix-package-search]: https://ahobson.github.io/nix-package-search/#/
 [docs-nix-channels]: https://nixos.wiki/wiki/Nix_channels
 [gh-nixpkgs]: https://github.com/NixOS/nixpkgs
+[hydra-nixpkgs-unstable]: https://hydra.nixos.org/job/nixpkgs/trunk/unstable


### PR DESCRIPTION
During an upgrade of a Nix package, we ran into a little rabbit hole and learned a lot about Nix Channels together. The Slack conversation is in a Project Slack and not Truss Slack, but we can continue having this conversation in [#code-nix](https://trussworks.slack.com/archives/C01KTH6HP7D) 🔒 to better improve our Nix documentation. 

The summary for this PR is that we may need to update certain references to commits on branches other than the default `nixpkgs-unstable` branch that is in our current documentation. Because of some of the limitations of GH Markdown, I'm using the `<details>` tag to have this documentation inline but also called out visually so folks don't lose sight of it while reading the documentation.

It's encouraged to both modify and discuss this branch.