### PR TITLE
Updates to terratest.md for clarity

### DIFF
--- a/infrasec/terraform/terratest.md
+++ b/infrasec/terraform/terratest.md
@@ -11,7 +11,7 @@ It executes the defined Terraform and then validates things you're asserting.
 - [Configure CircleCi to run the tests automatically](#configure-circleci-to-run-the-tests-automatically)
   - [Configure CircleCi Job](#configure-circleci-job)
   - [Update the Key rotator configuration](#update-the-key-rotator-configuration)
-  - [Configure AWS Keys for the CircleCI project](#configure-aws-keys-for-the-circleci-project)
+  - [Alternative: Configure AWS Keys for the CircleCI project](#alternative-configure-aws-keys-for-the-circleci-project)
   - [Access test metadata stored in CircleCI](#access-test-metadata-stored-in-circleci)
 - [Documentation links](#documentation-links)
 


### PR DESCRIPTION
Having been through adding terratest to the terraform-aws-bootstrap module, I changed the instructions here to add a little bit of clarity around:
* the way the workflow should look
* Configuration of the AWS keys via running rotator manually, and the prerequisites needed to run rotator manually
  * removed the paragraph on going into circleCI and configuring the keys since this was done via rotator running locally**
* Slight verbiage change to make it explicit where adding go binaries to $PATH and `go-junit-report` should happen

**Put that paragraph back in. Figured it's good to maintain that method, so added as an alternative.