### PR TITLE
Remove deprecated nix install flags

### DIFF
--- a/developing/configuration/README.md
+++ b/developing/configuration/README.md
@@ -3,15 +3,19 @@
 Projects should adhere to the following guidelines for managing configuration:
 
 1. Configuration values should be provided to programs via environment variables.
-2. Programs should validate configuration immediately when they are run.
-3. If config is incomplete or invalid, programs should:
+
+1. Programs should validate configuration immediately when they are run.
+
+1. If config is incomplete or invalid, programs should:
+
    1. Exit with a non-zero status
-   2. Print a helpful error message to assist humans in resolving the issue
-4. All environment values should be cataloged in a single location.
+   1. Print a helpful error message to assist humans in resolving the issue
+
+1. All environment values should be cataloged in a single location.
 
    - This should generally be a project's `[.envrc](../direnv/README.md)` file (values can be left blank as needed), although ecosystems that have a strong convention for this configuration living elsewhere should follow that convention.
    - The purpose of maintaining this catalog of environment variables is to document all possible configuration points.
 
-5. Projects should define default configuration for local development in an `.envrc.local` file. This file should be loaded from the project's main `.envrc` file if it exists. [Here is an example](https://github.com/CMSgov/easi-app/blob/master/.envrc#L77-L80).
+1. Projects should define default configuration for local development in an `.envrc.local` file. This file should be loaded from the project's main `.envrc` file if it exists. [Here is an example](https://github.com/CMSgov/easi-app/blob/master/.envrc#L77-L80).
 
 Following the above guidelines should yield projects with a setup that allows developers to get a new project clone running with minimal manual configuration.

--- a/developing/nix/README.md
+++ b/developing/nix/README.md
@@ -92,11 +92,10 @@ MacOS requires that we add an argument to the installation command. We also want
 do the single user installation. So to install, run:
 
 ```shell
-sh <(curl -L https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume --no-daemon
+sh <(curl -L https://nixos.org/nix/install)
 ```
 
 See the [macOS installation](https://nixos.org/manual/nix/stable/#sect-macos-installation)
-and [single user installation](https://nixos.org/manual/nix/stable/#sect-single-user-installation)
 instructions for more details.
 
 ## Getting started


### PR DESCRIPTION
--darwin-use-unencrypted-nix-store-volume is deprecated
and
--no-daemon is no longer supported and prevents the installer from running

Here's the output I got when trying to use these flags to install on a new laptop:
```
marty@martys-MacBook-Pro ~ % sh <(curl -L https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume --no-daemon
<... curl stuff omitted ...>
Warning: the flag --darwin-use-unencrypted-nix-store-volume
         is no longer needed and will be removed in the future.

Error: --no-daemon installs are no-longer supported on Darwin/macOS!
```