### PR TITLE
Add safe link to Redux DevTools extension

### DIFF
--- a/web/frontend/developer-experience.md
+++ b/web/frontend/developer-experience.md
@@ -2,9 +2,10 @@
 
 ## Debugging Tools
 
-The following browser extensions can be installed to assist with debugging React:
+The following browser extensions can be installed to assist with debugging React and Redux applications:
 
 - [React Developer Tools](https://github.com/facebook/react-devtools#installation)
+- [Redux DevTools Extension](https://github.com/reduxjs/redux-devtools/tree/main/packages/redux-devtools-extension)
 
 ## Style and Formatting
 


### PR DESCRIPTION
The old link to this extension was removed by Maz because the domain appeared to be abandoned or hijacked and was redirecting to unsavory materials. This PR restores the link to the extension with a safe(r) GitHub link.