### PR TITLE
Remove MilMove links that are out-of-date/private

### DIFF
--- a/leadership/eng-lead/README.md
+++ b/leadership/eng-lead/README.md
@@ -28,8 +28,6 @@ Guidance and resources for Application Engineering Leads.
     - [Decision Making Best Practices from KBase 🔒](https://docs.google.com/document/d/1E-ChpTosRcX_h17eXRcw0c8rMymDSmZS7Ur-HZwiNkw/)
     - [Tech Roles and Decision Making Practices on KBase (presentation)🔒](https://docs.google.com/presentation/d/1FOVJQC03WVLiIL2SV-IATg_Na_ES2i9bwqkYXquRq70/edit#slide=id.g7781eb1f6c_0_4)
 - Measuring Quality
-  - Example: [MilMove Quality Measures 🔒](https://docs.google.com/document/d/1-YMSTj6keTS6zYgvq3lTY0PDqO09z-hbY8MMrVRjwdU/)
 - Managing the Backlog
-  - Example: [MyMove: Balancing the Backlog 🔒](https://docs.google.com/document/d/1vDZWJfjEZKLWZhtANYfmGk4M89_wGFYD/edit)
 - List of technical requirements
   - Example (UNDER REVIEW): [Technical Requirements Checklist 🔒](https://docs.google.com/document/d/1ozaXs8FiI6tqRWS_mEmEx_PothTioJsOxHoYlJF0b3I/)


### PR DESCRIPTION
This came up in the DP3 Slack. That sometimes documentation for MilMove is out of date or private due to NDA. To prevent requests for access coming to the DP3 team, we're removing them from the playbook. If there is value in these documents, please consider adding them in a public space such as another document in this repository rather than linking directly to these Google Documents.