### PR TITLE
Update pre-commit cache key generation

### DIFF
--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: cache
         uses: actions/cache@v2
         with:
-          key: pre-commit-dot-cache-${{ hashFiles(".pre-commit-config.yaml") }}
+          key: pre-commit-dot-cache-${{ hashFiles('.pre-commit-config.yaml') }}
           path: ~/.cache/pre-commit
       - name: Pre-commit checks
         run: pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: cache
         uses: actions/cache@v2
         with:
-          key: pre-commit-dot-cache-{{ hashFiles(".pre-commit-config.yaml") }}
+          key: pre-commit-dot-cache-${{ hashFiles(".pre-commit-config.yaml") }}
           path: ~/.cache/pre-commit
       - name: Pre-commit checks
         run: pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: cache
         uses: actions/cache@v2
         with:
-          key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
+          key: pre-commit-dot-cache-{{ hashFiles(".pre-commit-config.yaml") }}
           path: ~/.cache/pre-commit
       - name: Pre-commit checks
         run: pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
Update the method of generating the pre-commit cache key. That was my mistake for not catching this before. `checksum` is from CircleCI; `hashFiles` is the GitHub Actions expression.