### PR TITLE
Remove custom breadcrumbs

### DIFF
--- a/docs/compliance/atos/overview.md
+++ b/docs/compliance/atos/overview.md
@@ -1,4 +1,4 @@
-# [ATOs](README.md) / Overview
+# Overview
 
 Every federal information system must go through NIST's [Risk Management Framework](../steps/) before it can be used to process federal information. This process culminates in a signed Authority to Operate (ATO) being issued. Because the ATO process is a complex, multi-step process which will constrain the design and implementation of your system, you should start thinking about how it applies to your system _before_ you begin designing and implementing it.
 

--- a/docs/developing/README.md
+++ b/docs/developing/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../README.md) / Tools and Practice
+# Tools and Practice
 
 ## Overview
 

--- a/docs/developing/bugs/README.md
+++ b/docs/developing/bugs/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Defects/Bugs
+# Defects/Bugs
 
 ## Overview
 

--- a/docs/developing/cicd/README.md
+++ b/docs/developing/cicd/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / CI/CD
+# CI/CD
 
 The release process is one of the most important parts of development
 for obvious reasons: without a release, your code is never going to

--- a/docs/developing/cicd/circleci-orbs.md
+++ b/docs/developing/cicd/circleci-orbs.md
@@ -1,4 +1,4 @@
-# [CI/CD](README.md) / CircleCI Orbs
+# CircleCI Orbs
 
 As defined by CircleCI, orbs are "a reusable package of YAML configuration that condenses repeated pieces of config into a single line of code." You can think of them as libraries you can import into the CircleCI configuration.
 

--- a/docs/developing/cicd/circleci-patterns.md
+++ b/docs/developing/cicd/circleci-patterns.md
@@ -1,4 +1,4 @@
-# [Intro to CI/CD](README.md) / CircleCI Config Patterns
+# CircleCI Config Patterns
 
 At Truss, CircleCI tends to be our CI/CD tool of choice. In order to help
 developers and infrastructure engineers get their pipelines working quickly,

--- a/docs/developing/cicd/circleci-utilities.md
+++ b/docs/developing/cicd/circleci-utilities.md
@@ -1,4 +1,4 @@
-# [CI/CD](README.md) / CircleCI Utilities
+# CircleCI Utilities
 
 There are common tasks that may be useful to build into CircleCI commands and jobs to inform more complex build pipeline logic. Since CircleCI does not support orbs designed to return values which can be passed into other commands as parameters, it can be difficult to create reusable orbs for these purposes.
 

--- a/docs/developing/cicd/delivery-pipeline.md
+++ b/docs/developing/cicd/delivery-pipeline.md
@@ -1,4 +1,4 @@
-# [CI/CD](README.md) / Standard Delivery Pipeline
+# Standard Delivery Pipeline
 
 The following is a standardized workflow for developing and deploying our
 code using CI/CD. This is meant to be an example, not a prescriptive

--- a/docs/developing/cicd/dependabot.md
+++ b/docs/developing/cicd/dependabot.md
@@ -1,4 +1,4 @@
-# [CI/CD](README.md) / Dependabot
+# Dependabot
 
 [Dependabot](https://dependabot.com/) is a tool to automatically find updates to dependencies in our repos.
 

--- a/docs/developing/cicd/intro.md
+++ b/docs/developing/cicd/intro.md
@@ -1,4 +1,4 @@
-# [CI/CD](README.md) / Intro to CI/CD
+# Intro to CI/CD
 
 The goal of CI/CD practice is to provide a workflow that can support
 frequent updates, good testing, consistent builds, and prompt deploys.

--- a/docs/developing/code-reviews/README.md
+++ b/docs/developing/code-reviews/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Code Reviews
+# Code Reviews
 
 ## Overview
 

--- a/docs/developing/command-line-tools/HOW2GORELEASER.md
+++ b/docs/developing/command-line-tools/HOW2GORELEASER.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Building internal tools with GoReleaser
+# Building internal tools with GoReleaser
 
 ## Overview
 

--- a/docs/developing/command-line-tools/README.md
+++ b/docs/developing/command-line-tools/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Command Line Tools
+# Command Line Tools
 
 ## Overview
 

--- a/docs/developing/cycle/README.md
+++ b/docs/developing/cycle/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Development Cycle
+# Development Cycle
 
 ## Overview
 

--- a/docs/developing/direnv/README.md
+++ b/docs/developing/direnv/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / direnv
+# direnv
 
 ## Overview
 

--- a/docs/developing/docker/README.md
+++ b/docs/developing/docker/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Docker
+# Docker
 
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 

--- a/docs/developing/eid/README.md
+++ b/docs/developing/eid/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Editors, IDEs and Debuggers
+# Editors, IDEs and Debuggers
 
 ## Overview
 

--- a/docs/developing/growth/README.md
+++ b/docs/developing/growth/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Growth
+# Growth
 
 ## Overview
 

--- a/docs/developing/healthcheck/README.md
+++ b/docs/developing/healthcheck/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Healthchecks
+# Health Checks
 
 ## Overview
 

--- a/docs/developing/languages/BASH.md
+++ b/docs/developing/languages/BASH.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../README.md) / Shell programming
+# Shell programming
 
 ## Overview
 

--- a/docs/developing/languages/README.md
+++ b/docs/developing/languages/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Programming Languages
+# Programming Languages
 
 ## Overview
 

--- a/docs/developing/languages/python/installation.md
+++ b/docs/developing/languages/python/installation.md
@@ -1,4 +1,4 @@
-# [Python](./README.md) / Installation
+# Installation
 
 ## Python
 

--- a/docs/developing/languages/python/linters_and_checkers.md
+++ b/docs/developing/languages/python/linters_and_checkers.md
@@ -1,3 +1,3 @@
-# [Python](./README.md) / Linters and Checkers
+# Linters and Checkers
 
 We recommend using [flake8](https://flake8.pycqa.org/en/latest/) as a linter and [black](https://black.readthedocs.io/en/stable/) for formatting.

--- a/docs/developing/languages/python/project_setup.md
+++ b/docs/developing/languages/python/project_setup.md
@@ -1,4 +1,4 @@
-# [Python](./README.md) / Project Setup
+# Project Setup
 
 ## Layout
 

--- a/docs/developing/languages/ruby/installation.md
+++ b/docs/developing/languages/ruby/installation.md
@@ -1,4 +1,4 @@
-# [Ruby](./README.md) / Installation
+# Installation
 
 ## Context
 

--- a/docs/developing/learning/README.md
+++ b/docs/developing/learning/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Learning Resources
+# Learning Resources
 
 ## Overview
 

--- a/docs/developing/learning/asking_for_help.md
+++ b/docs/developing/learning/asking_for_help.md
@@ -1,4 +1,4 @@
-# [Learning Resources](./README.md) / "Asking For Help"
+# Asking For Help
 
 When learning, it is expected one will encounter situations where you
 need help. *How* you ask for help is an important skill to develop.

--- a/docs/developing/learning/continuous_delivery.md
+++ b/docs/developing/learning/continuous_delivery.md
@@ -1,4 +1,4 @@
-# [Learning Resources](./README.md) / "Continuous Delivery"
+# Continuous Delivery
 
 _Continuous Delivery_ is yet another text that was very influential at the beginning of the DevOps movement, and continues to be a rich resource for modern software delivery.
 

--- a/docs/developing/learning/crucial_conversations.md
+++ b/docs/developing/learning/crucial_conversations.md
@@ -1,4 +1,4 @@
-# [Learning Resources](./README.md) / "Crucial Conversations"
+# Crucial Conversations
 
 _Crucial Conversations_ "gives you the tools to prepare for high-stakes conversations, transform anger and hurt feelings into powerful dialogue, and make it safe to talk about almost anything".
 

--- a/docs/developing/learning/goal.md
+++ b/docs/developing/learning/goal.md
@@ -1,4 +1,4 @@
-# [Learning Resources](./README.md) / "The Goal"
+# The Goal
 
 _The Goal_ has been an influential business book since the 1980's, looking at the delivery of value via the "Theory of Constraints". This view has also been useful in conceptualizing how value is delivered in software.
 

--- a/docs/developing/learning/radical_candor.md
+++ b/docs/developing/learning/radical_candor.md
@@ -1,4 +1,4 @@
-# [Learning Resources](./README.md) / "Radical Candor"
+# Radical Candor
 
 _Radical Candor_ is basically the Trussel Manager Standard Issue book. It informs a lot of how Trussels aspire to comport themselves with each other. (The revised/updated edition was released in Oct 2019.)
 

--- a/docs/developing/learning/release_it.md
+++ b/docs/developing/learning/release_it.md
@@ -1,4 +1,4 @@
-# [Learning Resources](./README.md) / "Release It!"
+# Release It
 
 _Release It!_ was originally published in 2007 and was one of the most influential books at the beginning of the DevOps movement. The second edition, published in 2018, refreshes the content and practices for use in modern environments where DevOps and microservices are accepted norms.
 

--- a/docs/developing/learning/the_effective_engineer.md
+++ b/docs/developing/learning/the_effective_engineer.md
@@ -1,4 +1,4 @@
-# [Learning Resources](./README.md) / "The Effective Engineer"
+# The Effective Engineer
 
 Edmond Lau's _The Effective Engineer_ is an excellent book that covers many
 aspects of engineering. The package ($249), available on Edmond's site, is

--- a/docs/developing/nix/README.md
+++ b/docs/developing/nix/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / nix
+# nix
 
 ## EXPERIMENT
 

--- a/docs/developing/open-source/README.md
+++ b/docs/developing/open-source/README.md
@@ -1,4 +1,4 @@
-# [Developing](../README.md) / Open Source
+# Open Source
 
 ## Overview
 

--- a/docs/developing/open-source/intent.md
+++ b/docs/developing/open-source/intent.md
@@ -1,4 +1,4 @@
-# [OpenSource](./README.md) / Open Source Statement of Intent
+# Open Source Statement of Intent
 
 At Truss, we prefer to open source our code whenever possible; there are a variety of reasons for this:
 

--- a/docs/developing/pairing/README.md
+++ b/docs/developing/pairing/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Pair Programming
+# Pair Programming
 
 ## Overview
 

--- a/docs/developing/pairing/pairing-framework/README.md
+++ b/docs/developing/pairing/pairing-framework/README.md
@@ -1,4 +1,4 @@
-# [Pairing](../README.md) / A Pairing Framework
+# A Pairing Framework
 
 There is a tendency during pairing to get lost in the weeds, chasing down bugs or going down various rabbit holes. By using these templates, pairs can keep on track to solve the specific goal at hand.
 

--- a/docs/developing/pairing/pairing-framework/formal-pairing.md
+++ b/docs/developing/pairing/pairing-framework/formal-pairing.md
@@ -1,4 +1,4 @@
-# [A Pairing Framework](../README.md) / Formal Pairing Template
+# Formal Pairing Template
 
 ## Session details
 

--- a/docs/developing/pairing/pairing-framework/mentoring-pairing.md
+++ b/docs/developing/pairing/pairing-framework/mentoring-pairing.md
@@ -1,4 +1,4 @@
-# [A Pairing Framework](../README.md) / Mentoring Pairing Template
+# Mentoring Pairing Template
 
 ## Session details
 

--- a/docs/developing/pairing/pairing-framework/planning-pairing.md
+++ b/docs/developing/pairing/pairing-framework/planning-pairing.md
@@ -1,4 +1,4 @@
-# [A Pairing Framework](../README.md) / Planning & Info Sharing Pairing Template
+# Planning & Info Sharing Pairing Template
 
 ## Session details
 

--- a/docs/developing/pairing/pairing-framework/support-pairing.md
+++ b/docs/developing/pairing/pairing-framework/support-pairing.md
@@ -1,4 +1,4 @@
-# [A Pairing Framework](../README.md) / Support Pairing Template
+# Support Pairing Template
 
 ## Session details
 

--- a/docs/developing/pairing/resources.md
+++ b/docs/developing/pairing/resources.md
@@ -1,4 +1,4 @@
-# [Pairing](../README.md) / Resources for Pairing
+# Resources for Pairing
 
 - [On Pair Programming](https://martinfowler.com/articles/on-pair-programming.html)
 - [Tuple’s Pair Programming Guide](https://tuple.app/pair-programming-guide)

--- a/docs/developing/slack/README.md
+++ b/docs/developing/slack/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Slack Best Practices
+# Slack Best Practices
 
 ## Overview
 

--- a/docs/developing/technical-design/README.md
+++ b/docs/developing/technical-design/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Technical Design
+# Technical Design
 
 ## Overview
 

--- a/docs/developing/vcs/README.md
+++ b/docs/developing/vcs/README.md
@@ -1,4 +1,4 @@
-# [Tools and Practice](../README.md) / Source Control
+# Source Control
 
 ## Overview
 

--- a/docs/developing/vcs/git-repos.md
+++ b/docs/developing/vcs/git-repos.md
@@ -1,4 +1,4 @@
-# [Source Control](./README.md) / Git Repos
+# Git Repos
 
 This page provides guidance on how to set up and manage your Git repos.
 For Truss, most of these will be kept in [GitHub](https://github.com),

--- a/docs/developing/vcs/git-workflow.md
+++ b/docs/developing/vcs/git-workflow.md
@@ -1,4 +1,4 @@
-# [Source Control](./README.md) / Git Workflow
+# Git Workflow
 
 At Truss, we've tried to come up with some standardized workflows for
 working with Git. This page hopes to capture them so that new Trussels

--- a/docs/developing/vcs/master-to-main.md
+++ b/docs/developing/vcs/master-to-main.md
@@ -1,4 +1,4 @@
-# [Source Control](./README.md) / Master to Main branch rename
+# Master to Main branch rename
 
 These instructions will help moving repos from using the default branch name `master` and modify it to be
 `main`.

--- a/docs/developing/vcs/tools.md
+++ b/docs/developing/vcs/tools.md
@@ -1,4 +1,4 @@
-# [Source Control](./README.md) / Tools
+# Tools
 
 This page provides a summary of tools we commonly use for source control
 at Truss.

--- a/docs/documentation/README.md
+++ b/docs/documentation/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../README.md) / Documentation
+# Documentation
 
 ## Overview
 

--- a/docs/documentation/adr.md
+++ b/docs/documentation/adr.md
@@ -1,4 +1,4 @@
-# [Documentation](./README.md) / Architectural Decision Records
+# Architectural Decision Records
 
 Truss uses [architectural decision records](https://adr.github.io/) (ADRs) to
 document engineering decisions. These include choices about composition of the

--- a/docs/documentation/external-resources.md
+++ b/docs/documentation/external-resources.md
@@ -1,4 +1,4 @@
-# [Documentation](./README.md) / External Resources
+# External Resources
 
 This is a list of articles and talks that have influenced the advice in
 this section; you may find it useful to read or view these if you're

--- a/docs/documentation/intro-to-docs.md
+++ b/docs/documentation/intro-to-docs.md
@@ -1,4 +1,4 @@
-# [Documentation](./README.md) / Introduction to Documentation
+# Introduction to Documentation
 
 Documentation is a key part of any software project, but it's often
 something that many engineers struggle with even if we recognize its

--- a/docs/incident-response/README.md
+++ b/docs/incident-response/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../README.md) / Incident Response
+# Incident Response
 
 ## Overview
 

--- a/docs/incident-response/analysis.md
+++ b/docs/incident-response/analysis.md
@@ -1,4 +1,4 @@
-# [Incident Response](./README.md) / Incident Analysis and Retrospectives
+# Incident Analysis and Retrospectives
 
 This documentation is not intended to be a complete guide to incident
 analysis; this is a complicated field and trying to sum this up in a

--- a/docs/incident-response/external-resources.md
+++ b/docs/incident-response/external-resources.md
@@ -1,4 +1,4 @@
-# [Incident Response](./README.md) / External Resources
+# External Resources
 
 This is a collection of external resources that may be useful for learning
 more about elements of incident response. Please feel free to submit PRs

--- a/docs/incident-response/on-call.md
+++ b/docs/incident-response/on-call.md
@@ -1,4 +1,4 @@
-# [Incident Response](../README.md) / On-Call Best Practices
+# On-Call Best Practices
 
 ## Overview
 

--- a/docs/incident-response/overview.md
+++ b/docs/incident-response/overview.md
@@ -1,4 +1,4 @@
-# [Incident Response](./README.md) / Overview
+# Overview
 
 Incident response for production systems owes a great deal to the incident
 response process developed by the National Forest Service and later

--- a/docs/incident-response/security-incidents.md
+++ b/docs/incident-response/security-incidents.md
@@ -1,4 +1,4 @@
-# [Incident Response](./README.md) / Security Incidents
+# Security Incidents
 
 While security incidents are similar to service-impacting incidents
 in many ways, they also have a unique set of challenges that we need

--- a/docs/infrasec/README.md
+++ b/docs/infrasec/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../README.md) / InfraSec
+# InfraSec
 
 Infrastructure and security engineering (infrasec) is the practice of
 building secure, robust systems that are foundational to having reliable

--- a/docs/infrasec/alert-providers.md
+++ b/docs/infrasec/alert-providers.md
@@ -1,4 +1,4 @@
-# [InfraSec](README.md) / Alert Providers
+# Alert Providers
 
 In general, we will be using a third party provider to take alerts from
 the systems which are doing the monitoring -- whether that's AWS

--- a/docs/infrasec/ansible/README.md
+++ b/docs/infrasec/ansible/README.md
@@ -1,4 +1,4 @@
-# [InfraSec](../README.md) / Ansible
+# Ansible
 
 Ansible is a configuration management tool that usually operates in a "headless" fashion, using remote execution via
 ssh to implement configuration changes. It is also common for it to be used as a provisioner in Packer, a tool we use

--- a/docs/infrasec/ansible/ansible-primer.md
+++ b/docs/infrasec/ansible/ansible-primer.md
@@ -1,4 +1,4 @@
-# [Ansible](README.md) / Ansible Primer
+# Ansible Primer
 
 Ansible is a Python-based configuration management tool owned and supported by Red Hat; while it is essentially a
 remote-execution tool originally designed to orchestrate a wider environment, it can also be used as a provisioning tool

--- a/docs/infrasec/ansible/molecule-primer.md
+++ b/docs/infrasec/ansible/molecule-primer.md
@@ -1,4 +1,4 @@
-# [Ansible](README.md) / Molecule Primer
+# Molecule Primer
 
 Molecule is the officially supported testing framework for Ansible. For now, this is mostly just a collection of
 experiences and resources you can use when adding testing to your own Ansible roles; take these with a grain of salt.

--- a/docs/infrasec/aws/README.md
+++ b/docs/infrasec/aws/README.md
@@ -1,4 +1,4 @@
-# [InfraSec](../README.md) / AWS
+# AWS
 
 AWS is the most popular cloud provider, accounting for about ⅓ of all cloud spend. Almost all our infrastructure client discoveries find they are already using or want to use AWS.
 

--- a/docs/infrasec/aws/aws-organizations.md
+++ b/docs/infrasec/aws/aws-organizations.md
@@ -1,4 +1,4 @@
-# [AWS](README.md) / AWS Organizations
+# AWS Organizations
 
 [AWS Organizations](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html)
 provide a native way to manage multiple AWS accounts.  They provide

--- a/docs/infrasec/aws/govcloud/README.md
+++ b/docs/infrasec/aws/govcloud/README.md
@@ -1,4 +1,4 @@
-# [AWS](../README.md) / Working in GovCloud
+# Working in GovCloud
 
 Many of our government clients will want to have at least their production
 infrastructure in [AWS GovCloud](https://aws.amazon.com/govcloud-us/), which

--- a/docs/infrasec/aws/govcloud/gov-acm.md
+++ b/docs/infrasec/aws/govcloud/gov-acm.md
@@ -1,4 +1,4 @@
-# [GovCloud](README.md) / ACM in GovCloud
+# ACM in GovCloud
 
 AWS Certificate Manager (ACM) is our preferred way to handle certificates
 in AWS whenever possible. Unfortunately, due to the fact that Route53

--- a/docs/infrasec/aws/govcloud/gov-orgs.md
+++ b/docs/infrasec/aws/govcloud/gov-orgs.md
@@ -1,4 +1,4 @@
-# [GovCloud](README.md) / Setting Up a GovCloud Organization
+# Setting Up a GovCloud Organization
 
 Setting up organizations in GovCloud requires some additional steps due
 to the way GovCloud interacts (or rather, doesn't interact) with commercial

--- a/docs/infrasec/aws/guardduty.md
+++ b/docs/infrasec/aws/guardduty.md
@@ -1,4 +1,4 @@
-# [AWS](README.md) / GuardDuty for Organizations
+# GuardDuty for Organizations
 
 [GuardDuty](https://aws.amazon.com/guardduty/) is an anomaly detection
 system that can alert you via SNS when it detects unusual activity within

--- a/docs/infrasec/aws/naming.md
+++ b/docs/infrasec/aws/naming.md
@@ -1,4 +1,4 @@
-# [AWS](README.md) / Naming
+# Naming
 
 *Naming* is one of the [hard problems in computing](https://martinfowler.com/bliki/TwoHardThings.html). Naming instances in a shared name space, such as AWS, is especially rife with problems. Often a company uses a single AWS account across multiple projects and so the projects have to negotiate how to share the namespace for resources. There are a number of different axes of belonging we might want to include in the name: to which project does a resource belong, to which environment (dev, prod, staging), which function within the environment. Then there are entities which exist only in terms of their relationship to other objects, e.g. roles associated with a particular lambda function.
 

--- a/docs/infrasec/aws/org-bootstrap.md
+++ b/docs/infrasec/aws/org-bootstrap.md
@@ -1,4 +1,4 @@
-# [AWS](README.md) / Bootstrapping an AWS Organization
+# Bootstrapping an AWS Organization
 
 The purpose of this document is to take you step by step through the
 process of bootstrapping an [AWS Organization](aws-organizations.md).

--- a/docs/infrasec/aws/sns-guardduty-alert-integrations.md
+++ b/docs/infrasec/aws/sns-guardduty-alert-integrations.md
@@ -1,4 +1,4 @@
-# [AWS](README.md) / Using SNS, GuardDuty, and External Integrations with AWS Organizations
+# Using SNS, GuardDuty, and External Integrations with AWS Organizations
 
 Ideally our infrastructure is flawless and impenetrable, but much of our work requires us to be aware of unexpected occurrences. We rely on a system using a number of AWS resources and services such as SNS, GuardDuty, and CloudWatch with external integrations such as Slack and PagerDuty to allow us to stay alert and aware of unforeseen or suspicious activity. This primer should describe our recommended current set up and allow you to set up your own system to achieve similar results. Please familiarize yourself with [Truss' conception of AWS Organizations](aws-organizations.md) before proceeding.
 

--- a/docs/infrasec/aws/sns-topics.md
+++ b/docs/infrasec/aws/sns-topics.md
@@ -1,4 +1,4 @@
-# [AWS](README.md) / SNS Topics
+# SNS Topics
 
 We are using SNS topics as mainly a way to round messages and event to other services such as PagerDuty or Slack.
 

--- a/docs/infrasec/aws/vpcs.md
+++ b/docs/infrasec/aws/vpcs.md
@@ -1,4 +1,4 @@
-# [AWS](README.md) / VPC Configuration
+# VPC Configuration
 
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 

--- a/docs/infrasec/book-club/README.md
+++ b/docs/infrasec/book-club/README.md
@@ -1,4 +1,4 @@
-# [InfraSec](README.md) / book-club
+# Book Club
 
 __First rule of Book Club is tell everyone about Book Club!__
 

--- a/docs/infrasec/bootstrap.md
+++ b/docs/infrasec/bootstrap.md
@@ -1,4 +1,4 @@
-# [InfraSec](README.md) / Project Bootstrap Guide
+# Project Bootstrap Guide
 
 When we're starting up a new project, often there is a period of time
 where the design and research team is doing their initial work, we don't

--- a/docs/infrasec/certs.md
+++ b/docs/infrasec/certs.md
@@ -1,4 +1,4 @@
-# [InfraSec](README.md) / SSL Certificates
+# SSL Certificates
 
 SSL Certificates are most commonly used to verify a server's identity and
 encrypt HTTP traffic. Usually, we try to use offerings like Amazon's

--- a/docs/infrasec/charter.md
+++ b/docs/infrasec/charter.md
@@ -1,4 +1,4 @@
-# [InfraSec](README.md) / InfraSec Practice Charter
+# InfraSec Practice Charter
 
 At Truss, we have a single practice combining infrastructure and security
 practices, which is a pattern that is becoming more prevalent in the

--- a/docs/infrasec/good-infra.md
+++ b/docs/infrasec/good-infra.md
@@ -1,4 +1,4 @@
-# [InfraSec](README.md) / Good Infrastructure - A Philosophy
+# Good Infrastructure - A Philosophy
 
 While the tools, techniques, and patterns we use to build our solutions are important, they often don't help us design and architect new things. What follows are some opinions about how to think about the work we do at a high level.
 

--- a/docs/infrasec/pro-dev.md
+++ b/docs/infrasec/pro-dev.md
@@ -1,4 +1,4 @@
-# [InfraSec](README.md) / Professional Development
+# Professional Development
 
 Trussels are allocated $1000 per year to spend on professional development.
 InfraSec Managers have noticed that some folks just don't know what to use this budget for.

--- a/docs/infrasec/teardown.md
+++ b/docs/infrasec/teardown.md
@@ -1,4 +1,4 @@
-# [InfraSec](README.md) / Project Teardown Guide
+# Project Teardown Guide
 
 When a project reaches the end of its lifetime and the client doesn't
 want to continue it, we need to teardown all the infrastructure we've

--- a/docs/infrasec/terraform/README.md
+++ b/docs/infrasec/terraform/README.md
@@ -1,4 +1,4 @@
-# [InfraSec](../README.md) / Terraform
+# Terraform
 
 ## Overview
 

--- a/docs/infrasec/terraform/atlantis.md
+++ b/docs/infrasec/terraform/atlantis.md
@@ -1,4 +1,4 @@
-# [Terraform](README.md) / Atlantis
+# Atlantis
 
 [Atlantis](https://runatlantis.io) is a Terraform automation tool which integrates with GitHub pull requests to automatically generate Terraform plans, hold them for approval, and then apply the Terraform changes and merge the branch. It also manages locks on namespaces, preventing conflicts between PRs on in the same Terraform namespace. Using Atlantis (or a similar tool like Terraform Cloud) is a way to ensure safe and auditable Terraform changes, something which is important for many Truss projects.
 

--- a/docs/infrasec/terraform/terraform-import.md
+++ b/docs/infrasec/terraform/terraform-import.md
@@ -1,4 +1,4 @@
-# [Terraform](README.md) / `terraform import`
+# `terraform import`
 
 If you're adding Terraform to an environment where Terraform was not being
 used, often you'll need to import existing resources into your Terraform

--- a/docs/infrasec/terraform/terraform-state-mv.md
+++ b/docs/infrasec/terraform/terraform-state-mv.md
@@ -1,4 +1,4 @@
-# [Terraform](README.md) / `terraform state mv` in Delicate Circumstances
+# `terraform state mv` in Delicate Circumstances
 
 Sometimes you have a preexisting resource that you'd like to replace with another version. That's why the `terraform state mv` command exists. The [Terraform documentation](https://www.terraform.io/docs/commands/state/mv.html) will give you an outline of the different circumstances in which you can use it (including when moving resource between state files).
 

--- a/docs/infrasec/terraform/terratest.md
+++ b/docs/infrasec/terraform/terratest.md
@@ -1,4 +1,4 @@
-# [Terraform](README.md) / Terratest Guide
+# Terratest Guide
 
 Terratest is a Go framework that is used to test Terraform infrastructure code.
 It executes the defined Terraform and then validates things you're asserting.

--- a/docs/infrasec/tutorials/README.md
+++ b/docs/infrasec/tutorials/README.md
@@ -1,0 +1,16 @@
+# Tutorials
+
+## AWS
+
+- [Setting Up Your AWS User](https://github.com/trussworks/legendary-waddle/blob/master/docs/how-to/setup-new-user.md) — How to set up your AWS user in the Truss internal infrastructure. You will need the assistance of someone with administrative privileges in our AWS organization to help you.
+- [Your First Lambda Function](./your_first_lambda_function.md) — A guide to deploying your first AWS Lambda Function with Go and Terraform.
+
+## CI/CD
+
+- [Honeycomb CircleCi Metrics](./circle-ci-honeycomb-integrations.md) - How to add Honeycomb to CircleCi for build metrics.
+
+## Security
+
+- [One-Time Passwords](./one-time-passwords.md) — How to set up one-time passwords for GitHub with 1Password.
+- [YubiKey Configuration Guide](./yubikey-configuration.md) — How to get and configure a YubiKey for use in commit signing.
+- [YubiKey SSO](./yubikey-sso.md) — How to configure a Google Account to use YubiKey (for GSuite admins).

--- a/docs/infrasec/tutorials/circle-ci-honeycomb-integrations.md
+++ b/docs/infrasec/tutorials/circle-ci-honeycomb-integrations.md
@@ -1,4 +1,4 @@
-# [InfraSec](./README.md) / CircleCi Honeycomb Integration
+# CircleCi Honeycomb Integration
 
 [Honeycomb](https://www.honeycomb.io/) provides CI integrations allowing better instrumentation of builds. One such integration is for CircleCi via an [Orb](https://github.com/honeycombio/buildevents-orb). This document provides a guide for adding Honeycomb instrumentation to CircleCi builds.
 

--- a/docs/infrasec/tutorials/fix-circleci-integrations.md
+++ b/docs/infrasec/tutorials/fix-circleci-integrations.md
@@ -1,4 +1,4 @@
-# [InfraSec](../README.md) / Fix CircleCI Integrations
+# Fix CircleCI Integrations
 
 It's happened time to time that the CircleCI integration in GitHub decides to peace out. What this looks like is the lack of a CircleCI status check next to a commit hash.
 

--- a/docs/infrasec/tutorials/one-time-passwords.md
+++ b/docs/infrasec/tutorials/one-time-passwords.md
@@ -1,4 +1,4 @@
-# [InfraSec](../README.md) / One-Time Passwords
+# One-Time Passwords
 
 One-Time Passwords (aka OTPs or TOPTs) are exactly what they sound like. They are randomly generated passwords that can only be used once. They are often used for two-factor or multi-factor authentication.
 

--- a/docs/infrasec/tutorials/your_first_lambda_function.md
+++ b/docs/infrasec/tutorials/your_first_lambda_function.md
@@ -1,4 +1,4 @@
-# [InfraSec](../README.md) / Deploying your first AWS Lambda Function with Go and Terraform
+# Deploying your first AWS Lambda Function with Go and Terraform
 
 This tutorial focuses on deploying a "Hello, World" Go program as a Lambda function using Terraform. The first section will cover creating the program in Go and the second section will cover writing the Terraform script that will deploy the program into AWS. As a bonus, we'll cover how you can configure AWS CloudWatch to invoke your Lambda function on a recurring schedule.
 

--- a/docs/infrasec/tutorials/yubikey-configuration.md
+++ b/docs/infrasec/tutorials/yubikey-configuration.md
@@ -1,4 +1,4 @@
-# [InfraSec](../README.md) / YubiKey Configuration Guide
+# YubiKey Configuration Guide
 
 <!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=2 -->
 

--- a/docs/leadership/README.md
+++ b/docs/leadership/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../README.md) / Leadership
+# Leadership
 
 ## Overview
 

--- a/docs/leadership/eng-lead/README.md
+++ b/docs/leadership/eng-lead/README.md
@@ -1,4 +1,4 @@
-# [Leadership](../README.md) / Engineering Lead
+# Engineering Lead
 
 ## Overview
 

--- a/docs/leadership/eng-management/README.md
+++ b/docs/leadership/eng-management/README.md
@@ -1,4 +1,4 @@
-# [Leadership](../README.md) / Engineering Management
+# Engineering Management
 
 ## Overview
 

--- a/docs/practices/appeng/adrs/README.md
+++ b/docs/practices/appeng/adrs/README.md
@@ -1,0 +1,7 @@
+# ADRs
+
+Below is a list of our current Architectural Decision Records
+
+- [0001 Use Typescript](./0001-use-typescript.md)
+- [0002 Distributed Tracing](./0002-distributed-tracing.md)
+- [0003 Open Source Application Code](./0003-open-source-application-code.md)

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../README.md) / Templates
+# Templates
 
 ## Overview
 

--- a/docs/templates/subject/README.md
+++ b/docs/templates/subject/README.md
@@ -1,4 +1,8 @@
-# [Parent Subject Area](../README.md) / Subject Area
+---
+title: Template subject
+---
+
+# Subject Area
 
 ## Overview
 

--- a/docs/templates/topic.md
+++ b/docs/templates/topic.md
@@ -1,4 +1,8 @@
-# [Subject Area](./README.md) / Topic
+---
+title: Template topic
+---
+
+# Topic
 
 *Topic* is _add a brief description of what the topic means in the context of this subject area_. E.g. Authentication is the process of establishing whether or not we can trust that the person or entity interacting with an application is who they claim to be. Login is an example of a user giving a password as credentials to authenticate that they are the rightful owner of the username they claim. *Authentication* should be distinguished from [Authorization](./authorization.md) which is the process of determining whether or not a person/entity is entitled to perform a particular action.
 

--- a/docs/web/README.md
+++ b/docs/web/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../README.md) / Web Development
+# Web Development
 
 ## Overview
 

--- a/docs/web/api/README.md
+++ b/docs/web/api/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../README.md) / [Web Development](../README.md) / API Guide
+# API Guide
 
 ## Overview
 

--- a/docs/web/api/rest-api-design/Concurrency-Control.md
+++ b/docs/web/api/rest-api-design/Concurrency-Control.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../../../README.md) / [Web Development](../../../README.md) / [API Guide](../../README.md) / [REST API Design](../README.md) / Concurrency Control
+# Concurrency Control
 
 When you have more than one client using your API, you might want to think about concurrency control.
 

--- a/docs/web/api/rest-api-design/HTTP-Methods.md
+++ b/docs/web/api/rest-api-design/HTTP-Methods.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../../../README.md) / [Web Development](../../../README.md) / [API Guide](../../README.md) / [REST API Design](../README.md) / HTTP Methods
+# HTTP Methods
 
 When using HTTP methods like PUT or GET in your REST API, it's important to comply with their definitions under the [HTTP/1.1 Standard](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).
 

--- a/docs/web/api/rest-api-design/README.md
+++ b/docs/web/api/rest-api-design/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../../README.md) / [Web Development](../../README.md) / [API Guide](../README.md) / REST API Design
+# REST API Design
 
 Most of this structure was pulled from [https://apiguide.readthedocs.io/en/latest/index.html](https://apiguide.readthedocs.io/en/latest/index.html) which is an API guide written by the AusDTO which appears to be the Aussie version of the U.S. Digital Services.
 

--- a/docs/web/browsersupport/README.md
+++ b/docs/web/browsersupport/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../README.md) / [Web Development](../README.md) / Browser Support
+# Browser Support
 
 ## Overview
 

--- a/docs/web/frontend/README.md
+++ b/docs/web/frontend/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../README.md) / [Web Development](../README.md) / Front End
+# Front End
 
 ## Overview
 

--- a/docs/web/frontend/architecture.md
+++ b/docs/web/frontend/architecture.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../README.md) / [Web Development](../README.md) / [Front End](./README.md) / Frontend Architecture
+# Frontend Architecture
 
 ## Selecting a version of Node.js
 

--- a/docs/web/frontend/developer-experience.md
+++ b/docs/web/frontend/developer-experience.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../README.md) / [Web Development](../README.md) / [Front End](./README.md) / Developer Experience
+# Developer Experience
 
 ## Debugging Tools
 

--- a/docs/web/frontend/developing-ui.md
+++ b/docs/web/frontend/developing-ui.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../README.md) / [Web Development](../README.md) / [Front End](./README.md) / Implementing UI
+# Implementing UI
 
 This is an attempt to document the process of implementing a web UI based on visual assets, functional requirements, and content specifications. Hopefully the steps below provide a framework for accomplishing work with a high fidelity to the original designs, but they are not a substitute for attention to detail and thorough understanding of HTML and CSS.
 

--- a/docs/web/frontend/project-checklist.md
+++ b/docs/web/frontend/project-checklist.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../README.md) / [Web Development](../README.md) / [Front End](./README.md) / Project Checklist
+# Project Checklist
 
 ## A Front End Application Lifecycle
 

--- a/docs/web/frontend/testing.md
+++ b/docs/web/frontend/testing.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../README.md) / [Web Development](../README.md) / [Front End](./README.md) / Testing
+# Testing
 
 ## Unit & partial frontend integration testing
 

--- a/docs/web/frontend/typescript.md
+++ b/docs/web/frontend/typescript.md
@@ -1,4 +1,4 @@
-# Engineering Playbook / Web Development / [Frontend Guide](./README.md) / TypeScript Resources
+# TypeScript Resources
 
 This is a list of resources helpful when learning TypeScript. This
 guide assumes a working knowledge of Javascript and is mainly intended

--- a/docs/web/server/README.md
+++ b/docs/web/server/README.md
@@ -1,0 +1,10 @@
+# Server
+
+## Overview
+
+These are our recommendations and best practices for server development at
+Truss.
+
+## Contents
+
+- [Golang](./go.md)

--- a/docs/web/testing/README.md
+++ b/docs/web/testing/README.md
@@ -1,4 +1,4 @@
-# [Engineering Playbook](../../README.md) / [Web Development](../README.md) / Testing Frameworks
+# Testing Frameworks
 
 ## Overview
 


### PR DESCRIPTION
Closes #252 

I did my best to only commit the changes I've made to the headers, but I added some landing pages as well. Docusaurus gets the `<h1>` heading in Markdown and uses it as a the title in the sidebar among various other places. This patch series removes the manual breadcrumbs so we can focus on letting Docusaurus do this for us automatically. The landing pages I added are for the ADRs section, the Web/Server section, and the InfraSec/Tutorials section. I have other changes incoming, but I didn't want to overwhelm the changelog in these patches.

<details>
<summary> With these changes we can hopefully have less geese-related incidents. 🤡 </summary>

![](https://media.giphy.com/media/H8HQc6MaMRxPa/giphy.gif)

</details>