### PR TITLE
Give templates titles

### DIFF
--- a/docs/developing/technical-design/design-document-template.md
+++ b/docs/developing/technical-design/design-document-template.md
@@ -1,3 +1,7 @@
+---
+title: Template Technical Design Document
+---
+
 # Title
 
 - Contributors:

--- a/docs/incident-response/retro-template.md
+++ b/docs/incident-response/retro-template.md
@@ -1,6 +1,10 @@
-# \[Short Title of Incident\]
+---
+title: Template retrospective
+---
 
-Date(s) of Incident: \[YYYY-MM-DD date or date range of incident\]
+# Short Title of Incident
+
+Date(s) of Incident: YYYY-MM-DD date or date range of incident
 
 ## Summary
 

--- a/docs/practices/appeng/adrs/template.md
+++ b/docs/practices/appeng/adrs/template.md
@@ -1,3 +1,7 @@
+---
+title: Template ADR
+---
+
 # Number - Title
 
 **Status:** Accepted/Superseded by:


### PR DESCRIPTION
This was inspired by the work of #252 and #261 but didn't quite fit in the scope
of those issues/PRs. This patch gives titles to the templates so they have names
that aren't based on the filename of the template. This also updates the
`retro-template.md` to not use square-brackets as these don't need to be escaped
for Docusaurus and our current Markdown linting enforces escaping them. The
escaped square-brackets just look off-putting.
