### PR TITLE
Fix broken links and throw if there are any in the future

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -9,5 +9,6 @@
   "MD033": false,
   "MD040": false,
   "MD041": false,
+  "MD042": false,
   "MD046": false
 }

--- a/docs/compliance/atos/overview.md
+++ b/docs/compliance/atos/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-Every federal information system must go through NIST's [Risk Management Framework](../steps/) before it can be used to process federal information. This process culminates in a signed Authority to Operate (ATO) being issued. Because the ATO process is a complex, multi-step process which will constrain the design and implementation of your system, you should start thinking about how it applies to your system _before_ you begin designing and implementing it.
+Every federal information system must go through NIST's [Risk Management Framework](./steps.md) before it can be used to process federal information. This process culminates in a signed Authority to Operate (ATO) being issued. Because the ATO process is a complex, multi-step process which will constrain the design and implementation of your system, you should start thinking about how it applies to your system _before_ you begin designing and implementing it.
 
 ## Definitions
 
@@ -20,7 +20,7 @@ For a full list, see the [NIST Glossary](https://csrc.nist.gov/Glossary).
 
 Roles in ATO processes typically include:
 
-- **Assessor**: Responsible for checking the compliance of systems; sit in an agency's Security team. Validates and verifies that the documented controls (see [Step 3](../steps/#step-3-implement-security-controls)) actually work, using the assessment cases (see [Step 4](../steps/#step-4-assess-security-controls)).
+- **Assessor**: Responsible for checking the compliance of systems; sit in an agency's Security team. Validates and verifies that the documented controls (see [Step 3](./steps#step-3-implement-security-controls)) actually work, using the assessment cases (see [Step 4](./steps#step-4-assess-security-controls)).
 - **Authorizing Official (AO)**: Responsible for overall impact categorization and risk acceptance. The AO is ultimately responsible for determining if the risk of operating the system is acceptable, and if so, issuing an Authority to Operate (ATO) for that system. They often Designate this responsibility to one or more other people.
 - **Information System Security Officer (ISSO)**: Supports the information security system, consults on control selection, organizes scanning process. Reports to the Information System Security Manager (ISSM).
 - **Penetration tester(s)**: Conducts the penetration test after terms are agreed to as documented in the Rules of Engagement (RoE).
@@ -41,7 +41,7 @@ Your system may need to be reassessed and re-authorized if your application team
 
 - Encryption methodologies
 - Administrative functionality within the application
-- The kinds of information you store (for example, [personally identifiable information (PII)](../categorization/#pii))
+- The kinds of information you store (for example, [personally identifiable information (PII)](./categorization.md#PII))
 - The external services used or how/what data flows to/from them
 - Anything that will requires an update to the System Security Plan, system diagram, etc.
 

--- a/docs/compliance/atos/steps.md
+++ b/docs/compliance/atos/steps.md
@@ -8,7 +8,7 @@ The steps in the process are as follows:
 
 ## Step 1: Categorize Information System
 
-The information systems' owner, working with the AO, categorizes the system based on the potential impact on the organization if the information system, or the information within it, is jeopardized. The system will end up with a category of _low_, _moderate_ or _high_, based on criteria described [here](/docs/compliance/ato/categorization/).
+The information systems' owner, working with the AO, categorizes the system based on the potential impact on the organization if the information system, or the information within it, is jeopardized. The system will end up with a category of _low_, _moderate_ or _high_, based on criteria described [here](./categorization.md).
 
 If your system will be providing novel or risky functions, or handling extremely sensitive data, do this as early as possible.
 

--- a/docs/developing/eid/README.md
+++ b/docs/developing/eid/README.md
@@ -38,14 +38,14 @@ List of editors that Truss engineers use (sorted alphabetically):
 
 ##### Plugins
 
-- [vim-ale](github.com:w0rp/ale) - Asynchronous code linter
-- [editorconfig](editorconfig/editorconfig-vim.git)
-- [vim-fugitive](github.com:tpope/vim-fugitive) - A Git wrapper so awesome, it should be illegal
-- [vim-go](github:fatih/vim-go) - golang development plugin for vim
-- [vim-javascript](pangloss/vim-javascript.git)
-- [vim-plug](github.com:junegunn/vim-plug) - Minimalist plugin manager
-- [vim-prettier](github.com:prettier/vim-prettier)
-- [Recover](github.com:chrisbra/Recover.vim) - Displays a diff before recovering a swap file
+- [vim-ale](https://github.com:w0rp/ale) - Asynchronous code linter
+- [editorconfig](https://github.com/editorconfig/editorconfig-vim)
+- [vim-fugitive](https://github.com:tpope/vim-fugitive) - A Git wrapper so awesome, it should be illegal
+- [vim-go](https://github:fatih/vim-go) - golang development plugin for vim
+- [vim-javascript](https://github.com/pangloss/vim-javascript)
+- [vim-plug](https://github.com:junegunn/vim-plug) - Minimalist plugin manager
+- [vim-prettier](https://github.com:prettier/vim-prettier)
+- [Recover](https://github.com:chrisbra/Recover.vim) - Displays a diff before recovering a swap file
 
 #### VS Code
 

--- a/docs/developing/pairing/pairing-framework/formal-pairing.md
+++ b/docs/developing/pairing/pairing-framework/formal-pairing.md
@@ -20,7 +20,7 @@
 
 (How often will you take breaks? Do you want to use Pomodoro?)
 
-### [Ticket number](ticket_url)
+### [Ticket number](#)
 
 ### Goals for the session
 

--- a/docs/developing/pairing/pairing-framework/support-pairing.md
+++ b/docs/developing/pairing/pairing-framework/support-pairing.md
@@ -6,7 +6,7 @@
 
 (Miro, Google Doc, Zoom, Tuple, CodeTogether, etc.)
 
-### [Ticket number](ticket_url)
+### [Ticket number](#)
 
 ### Goals for the session
 

--- a/docs/developing/technical-design/README.md
+++ b/docs/developing/technical-design/README.md
@@ -64,7 +64,7 @@ Find subject experts and stakeholders early to vet proposals.
 
 Once a design document is accepted,
 it becomes a resource for the Development Cycle.
-The [Development Cycle Guide](../../cycle/README.md)
+The [Development Cycle Guide](../cycle/README.md)
 provides a more in depth view of how Truss iterates on work
 and should be consulted for implementation.
 However, a design doc can be helpful with starting that process.

--- a/docs/practices/README.md
+++ b/docs/practices/README.md
@@ -6,12 +6,12 @@ which grow people and cultivate knowledge specifically around a domain or craft.
 These are the resources associated with the practices
 focusing on the disciplines within Engineering at Truss.
 
-## [Application Engineering](./appeng)
+## [Application Engineering](./appeng/README.md)
 
 Application Engineering (AppEng) is the practice area at Truss
 focused on building software applications--
 including and mostly dealing with web development.
 
-## [Infrastructure and Security Engineering](./infrasec)
+## [Infrastructure and Security Engineering](../infrasec/README.md)
 
 Infrastructure and Security Engineering (InfraSec) is the practice of building secure, robust systems that are foundational to having reliable applications and services.

--- a/docs/practices/appeng/README.md
+++ b/docs/practices/appeng/README.md
@@ -22,4 +22,4 @@ Tools and process for how we set technical direction and make decisions
 
 - [Decision Process](decision-process.md)--how to commit and revise practice level decisions
 - [Decision Values](decision-values.md)--a guide on how to make ADR decisions
-- [Records](./adrs)--the outcomes we've come to
+- [Records](./adrs/README.md)--the outcomes we've come to

--- a/docs/templates/subject/README.md
+++ b/docs/templates/subject/README.md
@@ -10,5 +10,4 @@ Use this space to give an overview of the Subject Area. Include the scope, conte
 
 ## Contents
 
-- [Topic](./topic.md) - links to a topic within the Subject Area
-- [Child Subject Area](./child_subject/README.md) - Links to a Subject Area contained within this one.
+- [Topic](#) - links to a topic within the Subject Area

--- a/docs/templates/topic.md
+++ b/docs/templates/topic.md
@@ -4,7 +4,7 @@ title: Template topic
 
 # Topic
 
-*Topic* is _add a brief description of what the topic means in the context of this subject area_. E.g. Authentication is the process of establishing whether or not we can trust that the person or entity interacting with an application is who they claim to be. Login is an example of a user giving a password as credentials to authenticate that they are the rightful owner of the username they claim. *Authentication* should be distinguished from [Authorization](./authorization.md) which is the process of determining whether or not a person/entity is entitled to perform a particular action.
+*Topic* is _add a brief description of what the topic means in the context of this subject area_. E.g. Authentication is the process of establishing whether or not we can trust that the person or entity interacting with an application is who they claim to be. Login is an example of a user giving a password as credentials to authenticate that they are the rightful owner of the username they claim. *Authentication* should be distinguished from [Authorization](#) which is the process of determining whether or not a person/entity is entitled to perform a particular action.
 
 ## Context
 
@@ -20,7 +20,7 @@ In the RoR world [Devise](https://github.com/plataformatec/devise) is a standard
 
 ### OAuth
 
-[OAuth](../security/oauth.md) is a standard pattern for delegating authorization across systems. It is well supported in most frameworks and ...
+[OAuth](#) is a standard pattern for delegating authorization across systems. It is well supported in most frameworks and ...
 
 ## Pitfalls
 
@@ -28,4 +28,4 @@ This is the place to point out any common gotchas, e.g. confusing authentication
 
 ## The Trussel Way
 
-Often we have to work within the constaints of the Client's existing frameworks and choices. In those cases the [Approaches](#approaches) and [Pitfalls](#pitfalls) sections should hopefully contain the information a Trussel needs to think critically about the choices and alternatives. On those occaisions where we have a blank slate or are being asked for recommendations, this section should give a sound default choice to pick an answer and move forward.
+Often we have to work within the constraints of the Client's existing frameworks and choices. In those cases the [Approaches](#approaches) and [Pitfalls](#pitfalls) sections should hopefully contain the information a Trussel needs to think critically about the choices and alternatives. On those occasions where we have a blank slate or are being asked for recommendations, this section should give a sound default choice to pick an answer and move forward.

--- a/docs/web/api/README.md
+++ b/docs/web/api/README.md
@@ -4,5 +4,5 @@
 
 These are recommendations for API development.
 
-- [REST API Design Guide](rest-api-design/)
+- [REST API Design Guide](./rest-api-design/README.md)
 - [GraphQL Design Guide](GraphQL-Design-Guide.md)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,5 +1,5 @@
-const lightCodeTheme = require('prism-react-renderer/themes/github');
-const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const lightCodeTheme = require('prism-react-renderer/themes/duotoneLight');
+const darkCodeTheme = require('prism-react-renderer/themes/duotoneDark');
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {
@@ -9,8 +9,8 @@ module.exports = {
   baseUrl: '/',
   organizationName: 'trussworks',
   trailingSlash: false,
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'throw',
   favicon: 'img/favicon.ico',
   projectName: 'Engineering-Playbook',
   themeConfig: {


### PR DESCRIPTION
Closes #255

This patch series fixes a bunch of broken links across the repository. I had to
commit a few of these without `pre-commit` due to some legacy _Markdown Lint
CLI_ rules. I'll fix those in another patch to address #256.

- [x] Have Docusaurus throw errors on broken links
- [x] Fixing links across Compliance documentation
- [x] Fix links across Developing documentation
- [x] Fix links across Practices documentation
- [x] Fix links across Templates documentation
- [x] Fix links across Web/API documentation
