### PR TITLE
Revise Ruby documentation to recommend asdf

### DIFF
--- a/docs/developing/languages/ruby/installation.md
+++ b/docs/developing/languages/ruby/installation.md
@@ -20,15 +20,15 @@ It's also possible to use Docker, instructions for which are at the bottom of th
 
 ### Setup Instructions
 
-You'll need to know if the project you are running requires a specific version of Ruby. The convention is for this to be defined in a project's `Gemfile`. Look for a line that looks like this:
+If you don't have a specific project in mind, install the [latest version that has been released](https://www.ruby-lang.org/en/news/) and then configure that to be the global default version.
+
+If you are planning to work on a specific project, you'll need to know what version of Ruby that project requires. The convention is for this to be defined in a project's `Gemfile`. Look for a line that looks like this:
 
 ```ruby
 ruby "~> 3.1.2"
 ```
 
 In the above example, any version of Ruby in the range `3.1.2` to `3.1.99999` will suffice.
-
-If you don't have a specific project in mind, install the [latest version that has been released](https://www.ruby-lang.org/en/news/).
 
 #### Install Prerequisites
 
@@ -101,7 +101,7 @@ To set the version to use within the current directory (which will be stored in 
 $ asdf local ruby 3.1.2
 ```
 
-To set the version to use globally by default:
+To set the version to use globally by default (handy for ad-hoc use):
 
 ```console
 $ asdf global ruby 3.1.2

--- a/docs/developing/languages/ruby/installation.md
+++ b/docs/developing/languages/ruby/installation.md
@@ -2,10 +2,6 @@
 
 ## Context
 
-Installing and configuring Ruby on a Mac is a common source of confusion and
-frustration for folks of all experience levels due to inconsistent and
-incomplete instructions found online.
-
 Although macOS ships with Ruby, it is not recommended to use it for development
 for several reasons:
 
@@ -16,52 +12,131 @@ for several reasons:
   should be assumed that everything under `/System/Library` is part of macOS and
   is administered by Apple. Files in those directories should not be modified.
 
-- [macOS will no longer include Ruby by default in future releases](https://developer.apple.com/documentation/macos_release_notes/macos_catalina_10_15_beta_9_release_notes).
+## For quick scripts
 
-## Approaches
-
-### Limited to one version of Ruby at a time
-
-- Install Ruby with homebrew
-
-- Install Ruby manually
-
-### Allows switching between multiple versions of Ruby
-
-- Install and configure a Ruby manager, then install Ruby
-
-- Use a vetted automated script that sets everything up for you
+It's possible to install Ruby using `homebrew`, however, it's difficult to install precise versions. For one-off uses, though, it's a reasonable approach.
 
 ## The Trussel Way
 
-For long-term day-to-day development, we recommend installing and using Ruby via
-a Ruby manager. Inevitably, when working with Ruby projects, you will need to
-install multiple different versions at the same time and switch between them.
+We recommend installing and managing Ruby using asdf.
 
-Depending on your preferences and needs, the two recommended ways to install and
-use Ruby on a Mac are via local installation of a Ruby manager, or via Docker.
+It's also possible to use Docker, instructions for which are at the bottom of this document.
 
-Reasons to use Docker:
+### Setup Instructions
 
-- You don't use Ruby regularly, and only need it occasionally, such as to
-  review candidate work samples
-- You don't want to install anything locally
+You'll need to know if the project you are running requires a specific version of Ruby. The convention is for this to be defined in a project's `Gemfile`. Look for a line that looks like this:
 
-### Local installation
+```ruby
+ruby "~> 2.7.2"
+```
 
-The easiest and most reliable way to install Ruby locally is via an automated
-[script] which installs the following tools (only if you don't already have them):
+In the above example, any version of Ruby in the range `2.7.2` to `2.7.99999` will suffice.
 
-- [Homebrew](https://brew.sh/)
-- Apple Command Line Tools (note that you do not need the full Xcode package)
-- [chruby](https://github.com/postmodern/chruby) (our recommended Ruby manager)
-- [ruby-install](https://github.com/postmodern/ruby-install) (chruby's companion
-  tool for installing different Ruby versions)
-- The latest version of Ruby at the time you run the script
-- [bundler](https://bundler.io/)
+#### Install Prerequisites
 
-The script also updates your shell startup file (such as `.bash_profile`) to
-properly configure `chruby`.
+- Install [Homebrew](https://brew.sh/)
+- Install Apple Command Line Tools using `xcode-select --install`
+
+#### Install `asdf`
+
+[asdf](https://asdf-vm.com) is a program that manages multiple language versions. It uses language-specific plugins to define the specifics for each language it supports. We'll be using [the officially supported plugin for Ruby](https://github.com/asdf-vm/asdf-ruby) in this guide.
+
+Install asdf using homebrew:
+
+```console
+$ brew install asdf
+```
+
+Then, configure your shell to load asdf. The following instructions are for ZSH (the default shell in macOS); for other shells or OSes, find the relevant section in [the asdf installation documentation](https://asdf-vm.com/guide/getting-started.html#_3-install-asdf).
+
+```console
+$ echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
+```
+
+Close your shell and open a new one. Type `asdf` and you should see something like the following:
+
+```console
+$ asdf
+version: v0.10.2
+
+MANAGE PLUGINS
+asdf plugin add <name> [<git-url>]      Add a plugin from the plugin repo OR,
+                                        add a Git repo as a plugin by
+                                        specifying the name and repo url
+
+...
+```
+
+If that is working, continue on to the next step.
+
+#### Install asdf-ruby
+
+To add support for Ruby to asdf, add the plugin:
+
+```console
+$ asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
+```
+
+Then ensure that you have a build environment setup to install Ruby:
+
+```console
+$ brew install openssl@1.1 readline
+$ export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)"
+```
+
+Then you can install the specific version of Ruby you identified earlier:
+
+```console
+$ asdf install ruby 2.7.2
+```
+
+This command will install the [ruby-build](https://github.com/rbenv/ruby-build) tool, which it will then use to compile and setup the version of Ruby specified. This will take a few minutes. If you have issues, [the ruby-build documentation](https://github.com/rbenv/ruby-build/wiki#troubleshooting) has some helpful tips.
+
+Close your terminal and open another one to reload the Ruby configuration.
+
+#### Enable a specific Ruby version
+
+Once you have installed a version of Ruby, you'll want to set that as the version for use by your project.
+
+To set the version to use within the current directory (which will be stored in a `.tool-versions` file):
+
+```console
+$ asdf local ruby 2.7.2
+```
+
+To set the version to use globally by default:
+
+```console
+$ asdf global ruby 2.7.2
+```
+
+#### Verify that it worked
+
+First, make sure that the `ruby` command is being resolved to one provided by asdf:
+
+```console
+$ which ruby
+/Users/<USERNAME>/.asdf/shims/ruby
+```
+
+If you see something like `/usr/bin/ruby`, then your shell isn't picking up your asdf configuration.
+
+Check that you have the correct Ruby installed:
+
+```console
+$ ruby --version
+ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin21]
+```
+
+#### Install bundler
+
+Almost all Ruby projects will need bundler installed. You can do that with:
+
+```console
+$ gem install bundler
+```
+
+At this point, you can probably switch over to your project's setup instructions. They will usually start off by telling you to run `bundle install`.
 
 ### What to do if you already have RVM or rbenv
 
@@ -115,6 +190,12 @@ Quit and relaunch Terminal/iTerm
 
 ### Using Ruby via Docker
 
+Using Docker makes sense if :
+
+- You don't use Ruby regularly, and only need it occasionally, such as to
+  review candidate work samples
+- You don't want to install anything locally
+
 1. [Install Docker](https://github.com/trussworks/Engineering-Playbook/tree/master/developing/docker#installation)
 1. `cd` into the directory of the Ruby project you want to work with
 1. Run a bash shell in Docker: `docker run -it --rm=true -v $PWD:$PWD -w $PWD ruby:${DESIRED_RUBY_VERSION}-slim bash`
@@ -124,25 +205,3 @@ For example, if you want an image with Ruby 2.6.4, you would run:
 ```
 docker run -it --rm=true -v $PWD:$PWD -w $PWD ruby:2.6.4-slim bash
 ```
-
-### Ruby managers
-
-The most popular tools that allow you to manage multiple installations of Ruby
-and switch between them are: RVM, rbenv, and chruby. We recommend
-[chruby](https://github.com/postmodern/chruby) because it is the smallest and
-easiest to understand. We like that it does not do some of the things that other
-tools do:
-
-- Does not hook `cd`.
-- Does not install executable shims.
-- Does not require Rubies be installed into your home directory.
-- Does not automatically switch Rubies by default.
-- Does not require write-access to the Ruby directory in order to install gems.
-
-References:
-
-- <https://kgrz.io/programmers-guide-to-choosing-ruby-version-manager.html>
-- <https://stevemarshall.com/journal/why-i-use-chruby/>
-- <https://linhmtran168.github.io/blog/2014/02/27/moving-from-rbenv-to-chruby/>
-
-[script]: https://github.com/monfresh/install-ruby-on-macos

--- a/docs/developing/languages/ruby/installation.md
+++ b/docs/developing/languages/ruby/installation.md
@@ -23,10 +23,12 @@ It's also possible to use Docker, instructions for which are at the bottom of th
 You'll need to know if the project you are running requires a specific version of Ruby. The convention is for this to be defined in a project's `Gemfile`. Look for a line that looks like this:
 
 ```ruby
-ruby "~> 2.7.2"
+ruby "~> 3.1.2"
 ```
 
-In the above example, any version of Ruby in the range `2.7.2` to `2.7.99999` will suffice.
+In the above example, any version of Ruby in the range `3.1.2` to `3.1.99999` will suffice.
+
+If you don't have a specific project in mind, install the [latest version that has been released](https://www.ruby-lang.org/en/news/).
 
 #### Install Prerequisites
 
@@ -73,17 +75,16 @@ To add support for Ruby to asdf, add the plugin:
 $ asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
 ```
 
-Then ensure that you have a build environment setup to install Ruby:
+Then ensure that you have a build environment setup to install Ruby. We're using the pre-built OpenSSL from homebrew as it more reliably installs than other options:
 
 ```console
-$ brew install openssl@1.1 readline
 $ export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)"
 ```
 
 Then you can install the specific version of Ruby you identified earlier:
 
 ```console
-$ asdf install ruby 2.7.2
+$ asdf install ruby 3.1.2
 ```
 
 This command will install the [ruby-build](https://github.com/rbenv/ruby-build) tool, which it will then use to compile and setup the version of Ruby specified. This will take a few minutes. If you have issues, [the ruby-build documentation](https://github.com/rbenv/ruby-build/wiki#troubleshooting) has some helpful tips.
@@ -97,13 +98,13 @@ Once you have installed a version of Ruby, you'll want to set that as the versio
 To set the version to use within the current directory (which will be stored in a `.tool-versions` file):
 
 ```console
-$ asdf local ruby 2.7.2
+$ asdf local ruby 3.1.2
 ```
 
 To set the version to use globally by default:
 
 ```console
-$ asdf global ruby 2.7.2
+$ asdf global ruby 3.1.2
 ```
 
 #### Verify that it worked
@@ -121,7 +122,7 @@ Check that you have the correct Ruby installed:
 
 ```console
 $ ruby --version
-ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin21]
+ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-darwin21]
 ```
 
 #### Install bundler

--- a/docs/developing/languages/ruby/installation.md
+++ b/docs/developing/languages/ruby/installation.md
@@ -12,10 +12,6 @@ for several reasons:
   should be assumed that everything under `/System/Library` is part of macOS and
   is administered by Apple. Files in those directories should not be modified.
 
-## For quick scripts
-
-It's possible to install Ruby using `homebrew`, however, it's difficult to install precise versions. For one-off uses, though, it's a reasonable approach.
-
 ## The Trussel Way
 
 We recommend installing and managing Ruby using asdf.


### PR DESCRIPTION
Based on [a Slack discussion](https://trussworks.slack.com/archives/CDJ9JAD26/p1657075184688319), we're now recommending that folks use asdf to manage Ruby.

I tested the steps locally, but without a fresh macOS installation, it's hard to be sure that there aren't any gaps to trip over. These guide revisions would benefit from someone who doesn't use Ruby already following along and looking for issues.