### PR TITLE
Fix node version in deploy script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.17.5
+          node-version: 16.16.0
 
       - name: Install yarn
         run: npm install yarn


### PR DESCRIPTION
The deploy is failing. See [this error from the latest build](https://github.com/trussworks/Engineering-Playbook/actions/runs/3338593747):

```
[2/4] Fetching packages...
error @docusaurus/core@2.0.0-rc.1: The engine "node" is incompatible with this module. Expected version ">=16.14". Got "14.17.5"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```
This PR updates the node version in the deploy script to match the version in the `.node-version` file.