### PR TITLE
Update deploy script to use node version file

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.16.0
+          node-version-file: '.node-version'
 
       - name: Install yarn
         run: npm install yarn


### PR DESCRIPTION
This PR updates the deploy script to use the node version hardcoded into the repo's `.node-version` file.

[Documentation here.](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file)