### PR TITLE
Add markdown link checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,3 @@ repos:
           - mdformat-gfm
           - mdformat-toc
           - mdformat-frontmatter
-
-  - repo: https://github.com/trussworks/pre-commit-hooks
-    rev: v1.1.0
-    hooks:
-      - id: circleci-validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,8 @@ repos:
           - mdformat-gfm
           - mdformat-toc
           - mdformat-frontmatter
+
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.10.3
+    hooks:
+      - id: markdown-link-check


### PR DESCRIPTION
- Remove circleci validate pre-commit hook since we don't use CircleCi here anymore.
- Add a pre-commit hook to check for dead links in markdown files.