### PR TITLE
Remove Yarn usage from the repository and the documentation

### DIFF
--- a/Brewfile.local
+++ b/Brewfile.local
@@ -1,3 +1,2 @@
 brew 'nodenv'
-brew 'yarn'
 brew 'pre-commit'

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Choose one of the following methods to install the dependencies.
 ```
 brew update
 brew install nodenv
-brew install yarn
 brew install pre-commit
 pre-commit install
 ```

--- a/docs/web/frontend/README.md
+++ b/docs/web/frontend/README.md
@@ -51,12 +51,12 @@ Various resources on React, Redux, etc, for a variety of learning styles.
 - _Watch_: [This video](https://www.youtube.com/watch?list=PLb0IAmt7-GS188xDYE-u1ShQmFFGbrk0v&v=nYkdrAPrdcw) from the introduction of Flux can be useful for some high-level background about the pattern (the MVC bashing is overdone, but otherwise this video is useful.)
 - _Do_: Roll your own React app! Make a little project of your own. This works well if you’re more hands-on. Here are some rough steps, but you’ll need to do a bit of filling-in-the-blanks:
   - Use [create-react-app](https://github.com/facebookincubator/create-react-app) to bootstrap a new React project.
-  - Figure out how to run the app live (hint: yarn start)
+  - Figure out how to run the app live (hint: npm run start)
   - Find and skim through some of the important files it made: `index.hmtl`, `index.js`, `App.js`. What do these look like they’re doing?
   - Change the page title to something of your choosing.
   - Create a new React [component](https://reactjs.org/docs/react-component.html) that has a `<button>` or something in it.
   - [import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) that component into `App.js`, and make sure you can see it!
-  - Write a new test for your component. (Hint: `yarn test`). create-react-app gives you Jest for free, look at its manual.
+  - Write a new test for your component. (Hint: `npm run test`). create-react-app gives you Jest for free, look at its manual.
   - Make the thing in your component clickable, even if it just does `alert(‘hey there!’)`
   - Add [React Router](https://github.com/ReactTraining/react-router) to your project.
   - Make a new component like the first one, and add routes so that they display depending on the URL. E.g:

--- a/docs/web/frontend/project-checklist.md
+++ b/docs/web/frontend/project-checklist.md
@@ -56,7 +56,9 @@
   - What will you use to transpile JS (i.e., Babel)
   - Do you need additional polyfills or plugins for your target output?
   - Do you want static type checking? (TypeScript / flow / PropTypes)
-  - What will you use for running scripts and managing dependencies (npm or yarn)?
+  - What will you use for running scripts and managing dependencies?
+    - Yarn is discouraged as brought up in [ADR 05 - JavaScript dependency
+      management](../../practices/appeng/adrs/0005-javascript-dependency-management.mdx).
   - Will you use a JS framework (React, vue, etc.)?
 - For CSS:
   - How do you want to write CSS?

--- a/fresh-brew.local
+++ b/fresh-brew.local
@@ -31,8 +31,5 @@ fi
 fancy_echo "Configuring Nodenv..."
 configure_shell_file_for_nodenv
 
-fancy_echo "Installing dependencies with Yarn..."
-yarn install
-
 fancy_echo "Launching the website..."
-yarn start
+npm run start

--- a/vale/Vocab/OSS-Docs/accept.txt
+++ b/vale/Vocab/OSS-Docs/accept.txt
@@ -67,3 +67,4 @@ callables
 (?i)enum
 (?i)subclassing
 (?i)changeset
+npm


### PR DESCRIPTION
- [x] Removing any guidance to installing Yarn
- [x] Refactoring the docs to mention using `npm run`
- [x] Adding `npm` to acceptable words
- [x] Further removing any remnants of `yarn` usage

I made changes above to have our Engineering Playbook abide by our [05
JavaScript dependency management
ADR](https://playbook.truss.dev/docs/practices/appeng/adrs/javascript-dependency-management).
