### PR TITLE
Add link to Terraform Learning documentation

### DIFF
--- a/docs/infrasec/terraform/README.md
+++ b/docs/infrasec/terraform/README.md
@@ -4,18 +4,6 @@
 
 Terraform is our tool of choice for automating our 'cloud infrastructure'. In particular, we expect all but the earliest of prototype [AWS](../aws/README.md) resources to be created/deployed using terraform rather than by hand.
 
-## Contents
-
-- [Semantic Versioning](#semantic-versioning)
-- [Splitting a git repo](#splitting-a-git-repo)
-- [Going public](#going-public)
-- [Publishing a release](#publishing-a-release)
-- [Updating a module for a new version of Terraform](#updating-a-module-for-a-new-version-of-terraform)
-- [Version not appearing in the registry](#version-not-appearing-in-the-registry)
-- [Terraform state mv](#terraform-state-mv)
-- [How to layout/structure a Terraform Project](#how-to-layoutstructure-a-terraform-project)
-- [How to test your Terraform code](#how-to-test-your-terraform-code)
-
 ### Semantic Versioning
 
 - When publishing a module for the first time, if you're uncertain what version to use, use `v1.0.0`

--- a/docs/infrasec/terraform/README.md
+++ b/docs/infrasec/terraform/README.md
@@ -4,6 +4,11 @@
 
 Terraform is our tool of choice for automating our 'cloud infrastructure'. In particular, we expect all but the earliest of prototype [AWS](../aws/README.md) resources to be created/deployed using terraform rather than by hand.
 
+If you're new to Terraform, you can find a very useful resource for beginners
+from HashiCorp's Learning platform.
+
+[➡️  Read **Get Started - AWS** HashiCorp Learning using Terraform.](https://developer.hashicorp.com/terraform/tutorials/aws-get-started)
+
 ### Semantic Versioning
 
 - When publishing a module for the first time, if you're uncertain what version to use, use `v1.0.0`


### PR DESCRIPTION
## This work is being done as part of the #appeng-infra learning discussion

[➡️ This work is being tracked in Trello here 🔒](https://trello.com/c/WPvVkxyh/9-compiling-resources-for-hashicorp-tutorials-in-a-single-place)

cc: @rpdelaney

Changes proposed in this pull request:

- [x] Removing table of contents for this page;
- [x] Added a section to call-out folks new to Terraform

This work is building off of #315 so that file paths don't get confusing. This
patch must not get merged in until #315 is merged into the default branch.
