### PR TITLE
Adding a tip for folks reading through

### DIFF
--- a/docs/developing/cicd/README.md
+++ b/docs/developing/cicd/README.md
@@ -1,5 +1,15 @@
 # CI/CD
 
+:::tip This topic is under review
+
+Hi! This section is currently under review. Please read the InfraSec guidance on
+this topic titled [**CI/CD according to Truss**](../../infrasec/ci_cd.md). While
+some of the documentation contained here is relevant and expands on CI/CD
+topics, it currently is too focused on CircleCI and isn't generic enough. Expect
+this section to be changing frequently.
+
+:::
+
 The release process is one of the most important parts of development
 for obvious reasons: without a release, your code is never going to
 actually be used by anyone. What follows are resources for setting


### PR DESCRIPTION
With the updated InfraSec documentation in #308 about CI/CD, this larger
non-practice focused section needs a little tip in the beginning for any folks
reading. We can remove it once we've settled on things there. 
