### PR TITLE
Add Further Reading link to NSA/CISA doc

### DIFF
--- a/docs/infrasec/ci_cd.md
+++ b/docs/infrasec/ci_cd.md
@@ -333,12 +333,17 @@ separate channel, then you have too many alerts.
 
 - DO: Apply the [steel cable] approach to building CI/CD.
 
+## Further reading
+
+- NSA & CISA's [Defending Continuous Integration/Continuous Delivery (CI/CD) Environments][nsa_securing]
+
 [adr_calver]: https://github.com/trussworks/template-tech-challenge/blob/main/docs/adr/0005-define-image-tag-schema.md
 [alert fatigue]: https://en.wikipedia.org/wiki/Alarm_fatigue
 [artifact storage]: https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
 [bitbucket pipelines]: https://bitbucket.org/product/features/pipelines
 [circleci]: https://circleci.com
 [github actions]: https://github.com/features/actions
+[nsa_securing]: https://media.defense.gov/2023/Jun/28/2003249466/-1/-1/0/CSI_DEFENDING_CI_CD_ENVIRONMENTS.PDF
 [steel cable]: https://playbook.truss.works/docs/01-how-we-execute/06-steel-cable/
 [^1]: https://vsupalov.com/docker-better-image-tags/
 [^2]: https://vsupalov.com/docker-latest-tag/


### PR DESCRIPTION
Changes proposed in this pull request:

- Add link to NSA/CISA doc on securing CI/CD
