### PR TITLE
fix: upgrade shell-quote to 1.8.4 (CVE-2026-9277)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "prism-react-renderer": "2.4.1",
         "react": "19.2.8",
         "react-dom": "19.2.8",
+        "shell-quote": "^1.8.4",
         "url-loader": "4.1.1"
       }
     },
@@ -16349,9 +16350,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prism-react-renderer": "2.4.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",
+    "shell-quote": "^1.8.4",
     "url-loader": "4.1.1"
   },
   "resolutions": {


### PR DESCRIPTION
## Summary
Upgrade shell-quote from 1.8.3 to 1.8.4 to fix CVE-2026-9277.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-9277 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-9277` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: shell-quote: shell-quote: Arbitrary code execution via command injection due to unescaped line terminators

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-9277` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
